### PR TITLE
Implement sit cat-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 google-generated-creds.json
 .sitconfig
 dist/**/*
+.sit

--- a/README.md
+++ b/README.md
@@ -19,25 +19,29 @@ sit init
 sit fetch master
 # Update sheet
 sit push master
+# cat-file
+sit cat-file
 ```
 
 ## 📖 Usage
 
 ```bash
 $ sit -h
-Usage: sit [options] [command]
+Usage: index [options] [command]
 
 sit cli
 
 Options:
-  -V, --version             output the version number
-  -h, --help                output usage information
+  -V, --version              output the version number
+  -h, --help                 output usage information
 
 Commands:
-  fetch [options] <branch>  fetch rows from Sheet
-  push [options] <branch>   push locales to Sheet
-  init                      create setting file (.sitconfig)
-  clasp                     clasp cli
+  fetch [options] <branch>   fetch rows from Sheet
+  push [options] <branch>    push locales to Sheet
+  cat-file [options] <hash>  cat sit objects
+  init                       create setting file (.sitconfig)
+  clasp                      clasp cli
+  repo                       repo cli
 ```
 
 ## ❤️ Support Sheets
@@ -58,9 +62,6 @@ The default settings are as follows:
 ```yaml
 ---
 version: "1.0.0"
-repo:
-  local: ./.sit
-  remote: *sheet_url
 sheet:
   gss:
     url: &sheet_url <your/GoogleSpreadSheet/url>
@@ -78,6 +79,9 @@ sheet:
         key:
           type: string
           description: キー
+repo:
+  local: ./.sit
+  remote: *sheet_url
 local:
   distDirPath: ./dist/locales
 ```

--- a/index.js
+++ b/index.js
@@ -54,6 +54,25 @@ program
   });
 
 program
+  .command('cat-file <hash>')
+  .description('cat sit objects')
+  .option(
+    '-t, --type',
+    'show object type'
+  )
+  .option(
+    '-s, --size',
+    'show object size'
+  )
+  .option(
+    '-p, --pretty-print',
+    "pretty-print object's content"
+  )
+  .action((hash, options) => {
+    sit().Repo.catFile(hash, options);
+  })
+
+program
   .useSubcommand(initCmd)
   .useSubcommand(claspCmd)
   .useSubcommand(repoCmd)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fs-extra": "^8.1.0",
     "google-spreadsheet": "^2.0.8",
     "js-yaml": "^3.13.1",
+    "recursive-readdir": "^2.2.2",
     "uuid": "^3.4.0"
   }
 }

--- a/sample/sit.js
+++ b/sample/sit.js
@@ -11,3 +11,7 @@ client.Sheet.fetch('master').then(result => {
 client.Sheet.push('master').then(result => {
   console.log(result);
 });
+
+client.Repo.catFile('fcd37b4', { isType: true });
+client.Repo.catFile('fcd37b4', { isSize: true });
+client.Repo.catFile('fcd37b4', { isPrettyPrint: true });

--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -2,17 +2,15 @@
 
 const {
   isExistFile,
-  yamlSafeLoad,
   mkdirSyncRecursive,
   writeSyncFile
 } = require('./utils/file');
 
-function Repo(opts) {
-  const { settingPath } = opts;
-  const yamlData = yamlSafeLoad(settingPath)
-    , localRepo = yamlData["repo"]["local"];
+const SitBaseRepo = require('./repos/SitBaseRepo');
 
-  const init = () => {
+class SitRepo extends SitBaseRepo {
+  init() {
+    const localRepo = this.localRepo;
 
     if (isExistFile(localRepo)) {
       console.log(`already exist local repo: ${localRepo}`);
@@ -30,9 +28,27 @@ function Repo(opts) {
     }
   }
 
-  return {
-    init
+  catFile(obj, opts) {
+    const { type, size, prettyPrint } = opts
+
+    this._objectFind(obj).then(sha => {
+      this._objectRead(sha).then(obj => {
+        if (type) {
+          console.log(obj.fmt);
+        }
+
+        if (size) {
+          console.log(obj.size);
+        }
+
+        if (prettyPrint) {
+          console.log(obj.serialize().toString());
+        }
+      }).catch(err => {
+        console.log(err);
+      })
+    })
   }
 }
 
-module.exports = Repo;
+module.exports = SitRepo;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,7 +3,7 @@
 const Validator = require('./Validator');
 const AppSheet = require('./Sheet');
 const AppLocal = require('./Local');
-const AppRepo = require('./Repo');
+const AppRepo = require('./SitRepo');
 
 function sit(opts) {
   const defaultOpts = {
@@ -19,12 +19,12 @@ function sit(opts) {
   var Sheet = {}
     , Repo = {};
 
-  const repo = AppRepo(opts);
+  const repo = new AppRepo(opts);
 
   if (validator.isValid()) {
 
-    const sheet = AppSheet(opts)
-      , local = AppLocal(opts)
+    const sheet = new AppSheet(opts)
+      , local = new AppLocal(opts)
 
     Sheet.fetch = (worksheetName) => {
       return new Promise((resolve, reject) => {
@@ -50,6 +50,14 @@ function sit(opts) {
 
   Repo.init = () => {
     return repo.init();
+  }
+
+  Repo.objectRead = (sha) => {
+    return repo.objectRead(sha)
+  }
+
+  Repo.catFile = (obj, opts) => {
+    return repo.catFile(obj, opts);
   }
 
   return {

--- a/src/main/repos/SitBaseRepo.js
+++ b/src/main/repos/SitBaseRepo.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const {
+  isExistFile,
+  isDir,
+  yamlSafeLoad,
+  mkdirSyncRecursive,
+  fileSafeLoad,
+  fileUnzip,
+  fileBasename
+} = require('../utils/file');
+
+const recursive = require('recursive-readdir');
+
+const SitBlob = require('./SitBlob');
+const SitTree = require('./SitTree');
+
+class SitBaseRepo {
+  constructor(opts) {
+    this.settingPath = opts.settingPath
+    this.localRepo = this._createLocalRepo(this.settingPath)
+  }
+
+  /*
+    Read object object_id from Git repository repo.
+    Return a SitObject whose exact type depends.
+  */
+  _objectRead(sha) {
+    let path = this._readFile(false, "objects", sha.slice(0, 2), sha.slice(2));
+
+    return new Promise((resolve, reject) => {
+      fileUnzip(path, false, (err, binary) => {
+        if (err) reject(err);
+
+        // Read object type
+        const x = binary.indexOf(' ');
+        const fmt = binary.slice(0, x);
+
+        // Read and validate object size
+        const y = binary.indexOf('\0', x);
+        const size = parseInt(binary.slice(x, y));
+        const data = binary.slice(y + 1);
+
+        if (size != (binary.length - y - 1)) {
+          const err = new Error(`Malformed object ${sha}: bad length.`)
+          reject(err);
+        }
+
+        // Pick constructor
+        let klass;
+        switch (fmt.toString()) {
+          case 'tree':
+            klass = SitTree;
+            break;
+          case 'blob':
+            klass = SitBlob;
+            break;
+          default:
+            const err = new Error(`Unknown type ${fmt}`);
+            reject(err);
+        }
+
+        resolve(new klass(this, data, size))
+      });
+    })
+  }
+
+  _objectFind(name, follow = true) {
+    return new Promise((resolve, reject) => {
+      this._objectResolve(name).then(shaArr => {
+        if (!shaArr) {
+          reject(new Error(`No such reference ${name}.`));
+        }
+
+        if (shaArr.length > 1) {
+          reject(new Error(`Ambigous reference ${name}: Cndidates are:\n - ${"\n-1".join(shaArr)}`));
+        }
+
+        let sha = shaArr[0];
+
+        if (follow) {
+          resolve(sha);
+        } else {
+          resolve(null);
+        }
+      });
+    });
+  }
+
+  /*
+    Resolve name to an object hxhash in repo.
+
+    This function is aware of:
+
+    - the HEAD literal
+    - short and long hashes
+    - branches
+    - remote branches
+  */
+  _objectResolve(name) {
+    const hashRE = new RegExp('^[0-9A-Fa-f]{1,40}$')
+    const smallHashRE = new RegExp('^[0-9A-Fa-f]{1,7}');
+
+    return new Promise((resolve, reject) => {
+      if (!name) {
+        resolve(null)
+      }
+
+      if (name == "HEAD") {
+        resolve([_refResolve("HEAD")])
+      }
+
+      if (name.match(hashRE)) {
+        if (name.length == 40) {
+          resolve([name.toLowerCase()])
+        } else if (name.match(smallHashRE)) {
+          // This is a small hash 4 seems to be the minimal length
+          // for sit to consider something a short hash.
+          // THis limit is documented in man sit-rev-parse
+          name = name.toLowerCase();
+          const prefix = name.slice(0, 2);
+          const fullPath = this._findOrCreateDir(false, "objects", prefix);
+
+          if (fullPath) {
+            let rem = name.slice(2);
+
+            recursive(fullPath, (err, files) => {
+              if (err) reject(err);
+              let candidates = files.map(file => {
+                let fileName = fileBasename(file);
+
+                if (fileName.startsWith(rem)) {
+                  return prefix + fileName
+                }
+              });
+
+              resolve(candidates);
+            });
+          }
+        }
+      }
+    });
+  }
+
+  _createLocalRepo(path) {
+    const yamlData = yamlSafeLoad(path);
+    return yamlData["repo"]["local"];
+  }
+
+  _refResolve(ref) {
+    let data = fileSafeLoad(this._readFile(false, ref));
+    data = data.trim();
+
+    if (data.startsWith("ref: ")) {
+      return this._refResolve(data.slice(5))
+    } else {
+      return data
+    }
+  }
+
+  /*
+    For example, _readFile(true, "refs", "remotes", "origin", "HEAD") will create
+    .sit/refs/remotes/origin.
+  */
+  _readFile(mkdir = false, ...path) {
+    if (this._findOrCreateDir(mkdir, ...path.slice(0, -1))) {
+      return this._getPath(...path)
+    }
+  }
+
+  _findOrCreateDir(mkdir = false, ...path) {
+    path = this._getPath(...path);
+
+    if (isExistFile(path)) {
+      if (isDir(path)) {
+        return path;
+      } else {
+        throw new Error(`Not a direcotry ${path}`);
+      }
+    }
+
+    if (mkdir) {
+      mkdirSyncRecursive(path);
+      return path;
+    } else {
+      return null
+    }
+  }
+
+  _getPath(...path) {
+    return `${this.localRepo}/${path.join('/')}`;
+  }
+}
+
+module.exports = SitBaseRepo;

--- a/src/main/repos/SitBlob.js
+++ b/src/main/repos/SitBlob.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const SitObject = require('./SitObject');
+
+class SitBlob extends SitObject {
+  constructor(repo, data, size) {
+    super(repo, data, size);
+
+    this.fmt = 'blob';
+  }
+
+  serialize() {
+    return this.data;
+  }
+
+  deserialize(data) {
+    this.data = data;
+  }
+}
+
+module.exports = SitBlob;

--- a/src/main/repos/SitObject.js
+++ b/src/main/repos/SitObject.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class SitObject {
+  constructor(repo, data, size) {
+    this.repo = repo;
+    this.data = data;
+    this.size = size;
+    this.deserialize(data);
+  }
+}
+
+module.exports = SitObject;

--- a/src/main/repos/SitTree.js
+++ b/src/main/repos/SitTree.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const SitObject = require('./SitObject');
+
+class SitTree extends SitObject {
+  constructor(repo, data, size) {
+    super(repo, data, size);
+    this.fmt = 'tree';
+  }
+}
+
+module.exports = SitTree;

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,12 +51,25 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -79,6 +92,11 @@ commander@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
   integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -366,6 +384,13 @@ mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+minimatch@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 mixme@^0.3.1:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
@@ -405,6 +430,13 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+recursive-readdir@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
+  dependencies:
+    minimatch "3.0.4"
 
 request@^2.69.0, request@^2.72.0, request@^2.74.0:
   version "2.88.0"


### PR DESCRIPTION
## Work

```
$ node index.js cat-file -h
Usage: index cat-file [options] <hash>

cat sit objects

Options:
  -t, --type          show object type
  -s, --size          show object size
  -p, --pretty-print  pretty-print object's content
  -h, --help          output usage information
```

```
$ node index.js cat-file -t fcd37b4
blob
```

```
$ node index.js cat-file -s fcd37b4
4828
```

```
$ node index.js cat-file -p fcd37b4
'use strict';

const {
  isExistFile,
  isDir,
  yamlSafeLoad,
  mkdirSyncRecursive,
  writeSyncFile,
  fileSafeLoad,
  fileUnzip
} = require('./utils/file');

const SitBlob = require('./repos/SitBlob');
const SitTree = require('./repos/SitTree');

# 省略
```