### PR TITLE
Fix error when sit checkout typo_origin hoge

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -205,6 +205,15 @@ class SitRepo extends SitBaseRepo {
     let isRemote;
 
     if (repoName) {
+      if (!this.remoteRepo(repoName)) {
+        console.error(`\
+fatal: '${repoName}' does not appear to be a sit repository
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights and the repository exists.`);
+        return
+      }
+
       if (name) {
         isRemote = true
       } else {

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -324,7 +324,7 @@ describe('SitRepo', () => {
         })
       })
 
-      // 
+      //
       describe('when currentBranch is not checkout branch', () => {
         it('should return correctly', () => {
           const mockObj = new SitBlob(model, '1,2,3', 3)
@@ -358,7 +358,7 @@ describe('SitRepo', () => {
         expect(mockModel__writeLog).toHaveBeenCalledTimes(1)
         expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/refs/heads/test", null, "a7092c2cd3447d0f953e46b8cf81dd59e6745222", "branch: Created from refs/remotes/origin/test"])
 
-        // checkout test
+        // checkout test (2 times)
 
         expect(mockModel__objectFind).toHaveBeenCalledTimes(1)
         expect(mockModel__objectFind.mock.calls[0]).toEqual(["test"])
@@ -376,22 +376,38 @@ describe('SitRepo', () => {
         })
       })
 
-      describe('hwn checkout branch is new branch', () => {
-        console.log = jest.fn()
-        const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
-        const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
-        model.checkout(null, null, { branch: 'new_branch' })
+      describe('when checkout branch is new branch', () => {
+        it('should return correctly', () => {
+          console.log = jest.fn()
+          const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
+          const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
+          model.checkout(null, null, { branch: 'new_branch' })
 
-        expect(mockModel__writeSyncFile).toHaveBeenCalledTimes(2)
-        expect(mockModel__writeSyncFile.mock.calls[0]).toEqual(["HEAD", "ref: refs/heads/new_branch", false])
-        expect(mockModel__writeSyncFile.mock.calls[1]).toEqual(["refs/heads/new_branch", "953b3794394d6b48d8690bc5e53aa2ffe2133035", false])
+          expect(mockModel__writeSyncFile).toHaveBeenCalledTimes(2)
+          expect(mockModel__writeSyncFile.mock.calls[0]).toEqual(["HEAD", "ref: refs/heads/new_branch", false])
+          expect(mockModel__writeSyncFile.mock.calls[1]).toEqual(["refs/heads/new_branch", "953b3794394d6b48d8690bc5e53aa2ffe2133035", false])
 
-        expect(mockModel__writeLog).toHaveBeenCalledTimes(2)
-        expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/HEAD", "953b3794394d6b48d8690bc5e53aa2ffe2133035", "953b3794394d6b48d8690bc5e53aa2ffe2133035", "checkout: moving from master to new_branch"])
-        expect(mockModel__writeLog.mock.calls[1]).toEqual(["logs/refs/heads/new_branch", null, "953b3794394d6b48d8690bc5e53aa2ffe2133035", "branch: Created from HEAD"])
+          expect(mockModel__writeLog).toHaveBeenCalledTimes(2)
+          expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/HEAD", "953b3794394d6b48d8690bc5e53aa2ffe2133035", "953b3794394d6b48d8690bc5e53aa2ffe2133035", "checkout: moving from master to new_branch"])
+          expect(mockModel__writeLog.mock.calls[1]).toEqual(["logs/refs/heads/new_branch", null, "953b3794394d6b48d8690bc5e53aa2ffe2133035", "branch: Created from HEAD"])
 
-        expect(console.log).toHaveBeenCalledTimes(1)
-        expect(console.log.mock.calls[0]).toEqual(["Switched to a new branch 'new_branch'"])
+          expect(console.log).toHaveBeenCalledTimes(1)
+          expect(console.log.mock.calls[0]).toEqual(["Switched to a new branch 'new_branch'"])
+        })
+      })
+
+      describe('when repoName do not exist', () => {
+        it('should return correctly', () => {
+          console.error = jest.fn()
+          model.checkout('typo_origin', 'test')
+
+          expect(console.error).toHaveBeenCalledTimes(1)
+          expect(console.error.mock.calls[0][0]).toEqual(`\
+fatal: 'typo_origin' does not appear to be a sit repository
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights and the repository exists.`)
+        })
       })
     })
   })

--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -34,7 +34,12 @@ class SitBaseRepo extends SitBase {
   }
 
   remoteRepo(repoName) {
-    return SitConfig.config('local').remote[repoName].url;
+    const repoData = SitConfig.config('local').remote[repoName]
+    if (repoData) {
+      return repoData.url
+    } else {
+      return null
+    }
   }
 
   _refCSVData(branch, repoName) {

--- a/src/main/repos/base/__tests__/SitBaseRepo.spec.js
+++ b/src/main/repos/base/__tests__/SitBaseRepo.spec.js
@@ -32,8 +32,16 @@ describe('SitBaseRepo', () => {
   });
 
   describe('#repoName', () => {
-    it('should return correclty', () => {
-      expect(model.remoteRepo('origin')).toEqual('https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=0');
+    describe('when repoName exist', () => {
+      it('should return correclty', () => {
+        expect(model.remoteRepo('origin')).toEqual('https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=0');
+      })
+    })
+
+    describe('when repoName do not exist', () => {
+      it('should return correctly', () => {
+        expect(model.remoteRepo('typo_origin')).toEqual(null)
+      })
     })
   });
 


### PR DESCRIPTION
## Summary

Fix #58

## Work

```
$ node index.js checkout oigin fuga
fatal: 'oigin' does not appear to be a sit repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.666s)

Test Suites: 11 passed, 11 total
Tests:       127 passed, 127 total
Snapshots:   0 total
Time:        6.377s
Ran all test suites.
```