### PR TITLE
Fix error when sit fetch typo_origin master

### DIFF
--- a/src/main/__tests__/index.spec.js
+++ b/src/main/__tests__/index.spec.js
@@ -30,13 +30,11 @@ describe('sit', () => {
     describe('when remoteRepo do not exist', () => {
       it('should return correctly', () => {
         console.error = jest.fn()
-        SitRepo.prototype.remoteRepo = mockSitRepo_remoteRepo
-        mockSitRepo_remoteRepo.mockReturnValueOnce(undefined)
-        sit().Repo.fetch('origin', 'master')
+        sit().Repo.fetch('typo_origin', 'master')
 
         expect(console.error).toHaveBeenCalledTimes(1)
         expect(console.error.mock.calls[0]).toEqual([`\
-fatal: 'origin' does not appear to be a sit repository
+fatal: 'typo_origin' does not appear to be a sit repository
 fatal: Could not read from remote repository.
 
 Please make sure you have the correct access rights and the repository exists.`])

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -29,7 +29,7 @@ function sit(opts) {
   Repo.fetch = (repoName, branch, opts = {}) => {
     const { prune, verbose } = opts;
 
-    if (repo.remoteRepo(repoName) === undefined) {
+    if (!repo.remoteRepo(repoName)) {
       console.error(`\
 fatal: '${repoName}' does not appear to be a sit repository
 fatal: Could not read from remote repository.


### PR DESCRIPTION
## Summary

Fix #50 

## Work

```
$ node index.js fetch hoge master
fatal: 'hoge' does not appear to be a sit repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js

Test Suites: 11 passed, 11 total
Tests:       127 passed, 127 total
Snapshots:   0 total
Time:        4.61s, estimated 5s
Ran all test suites.
```