### PR TITLE
Fix error when sit clone origin invalid_url

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -11,9 +11,7 @@ const {
 
 function sit(opts) {
   const defaultOpts = {
-    type: 'GoogleSpreadSheet',
-    baseURL: 'https://docs.google.com/spreadsheets/d/',
-    worksheetIndex: 0
+    type: 'GoogleSpreadSheet'
   };
 
   let gopts = Object.assign({}, defaultOpts, opts);
@@ -219,7 +217,7 @@ remote: done.`);
           }).catch(err => {
             console.error(`fatal: Couldn't find remote ref 'master'`);
           });
-        }).catch(err => {
+        }).catch(_err => {
           console.error(`fatal: repository '${url}' not found`);
         });
       } else {

--- a/src/main/sheets/GSS.js
+++ b/src/main/sheets/GSS.js
@@ -13,8 +13,7 @@ class GSS {
   constructor(opts = {}) {
     const defaultOpts = {
       type: 'GoogleSpreadSheet',
-      baseURL: 'https://docs.google.com/spreadsheets/d/',
-      worksheetIndex: 0
+      baseURL: 'https://docs.google.com/spreadsheets/d'
     };
     const gopts = Object.assign({}, defaultOpts, opts);
 

--- a/src/main/sheets/GSSClient.js
+++ b/src/main/sheets/GSSClient.js
@@ -7,7 +7,7 @@ const SitSetting = require('../SitSetting');
 
 const _createSheetId = (uri, baseURL) => {
   // https://teratail.com/questions/116620
-  const regExp = new RegExp(`${baseURL}(.*?)/.*?`);
+  const regExp = new RegExp(`${baseURL}/(.*?)/.*?`);
   const sheetId = uri.match(regExp)[1];
   return sheetId;
 }


### PR DESCRIPTION
## Summary

Fix #36 

## Work

```
$ node index.js clone origin https://docs.google.com/spreadshe
fatal: repository 'https://docs.google.com/spreadshe' not found
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js

Test Suites: 11 passed, 11 total
Tests:       127 passed, 127 total
Snapshots:   0 total
Time:        4.869s, estimated 5s
Ran all test suites.
```