### PR TITLE
Check sheet header when sit fetch --prune origin

### DIFF
--- a/src/main/monkey_patches/google-spreadsheet.js
+++ b/src/main/monkey_patches/google-spreadsheet.js
@@ -1,0 +1,17 @@
+const {
+  GoogleSpreadsheet,
+  GoogleSpreadsheetRow,
+  GoogleSpreadsheetFormulaError
+} = require('google-spreadsheet');
+
+const {
+  GoogleSpreadsheetWorksheet
+} = require('./google-spreadsheet/GoogleSpreadsheetWorksheet')
+
+module.exports = {
+  GoogleSpreadsheet,
+  GoogleSpreadsheetWorksheet,
+  GoogleSpreadsheetRow,
+
+  GoogleSpreadsheetFormulaError,
+};

--- a/src/main/monkey_patches/google-spreadsheet/GoogleSpreadsheetWorksheet.js
+++ b/src/main/monkey_patches/google-spreadsheet/GoogleSpreadsheetWorksheet.js
@@ -1,0 +1,13 @@
+const { GoogleSpreadsheetWorksheet } = require('google-spreadsheet');
+
+// Copy from https://github.com/theoephraim/node-google-spreadsheet/blob/786be59c75f34c9deae0b184885173c6812583ad/lib/GoogleSpreadsheetWorksheet.js#L483-L488
+// this uses the "values" getter and does not give all the info about the cell contents
+// it is used internally when loading header cells
+GoogleSpreadsheetWorksheet.prototype.getCellsInRange = async function (a1Range, options) {
+  const response = await this._spreadsheet.axios.get(`/values/${encodeURIComponent(this.a1SheetName)}!${a1Range}`, {
+    params: options,
+  });
+  return response.data.values || [];
+}
+
+module.exports = GoogleSpreadsheetWorksheet;

--- a/src/main/sheets/GSSClient.js
+++ b/src/main/sheets/GSSClient.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { GoogleSpreadsheet } = require('google-spreadsheet');
+const { GoogleSpreadsheet } = require('../monkey_patches/google-spreadsheet');
 
 const { jsonSafeLoad } = require('../utils/file');
 const SitSetting = require('../SitSetting');

--- a/src/main/sheets/__tests__/GSS.spec.js
+++ b/src/main/sheets/__tests__/GSS.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const GSS = require('@sheets/GSS')
-const Client = require('@sheets/GSSClient')
 
 describe('GSS', () => {
   const model = new GSS()
@@ -12,8 +11,18 @@ describe('GSS', () => {
 
   describe('#loadInfo', () => {
     it('should return correctly', (done) => {
-      model.loadInfo('origin', 'refs/remotes', (result) => {
-        expect(result["spreadsheetId"]).toEqual('1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k')
+      model.loadInfo('origin', (doc, sheets) => {
+        expect(doc).not.toBeNull()
+        expect(sheets).not.toBeNull()
+        done()
+      })
+    })
+  })
+
+  describe('#getSheetNames', () => {
+    it('should return correctly', (done) => {
+      model.getSheetNames('origin', (result) => {
+        expect(result).not.toBeNull()
         done()
       })
     })

--- a/src/main/utils/array.js
+++ b/src/main/utils/array.js
@@ -102,6 +102,10 @@ const diffArray = (to, from) => {
   }
 }
 
+const isEqual = (to, from) => {
+  return JSON.stringify(to) == JSON.stringify(from)
+}
+
 // https://www.nxworld.net/tips/js-array-filter-snippets.html
 const _getDuplicateValues = ([...array]) => {
   return array.filter((value, index, self) => self.indexOf(value) === index && self.lastIndexOf(value) !== index);
@@ -115,5 +119,6 @@ const _getUniqueValues = ([...array]) => {
 module.exports = {
   csv2JSON,
   overrideCSV,
-  diffArray
+  diffArray,
+  isEqual
 }


### PR DESCRIPTION
## Summary

Fix #55 

## Work

`test` sheet don't have header.

![image](https://user-images.githubusercontent.com/11146767/74341867-d5551e00-4deb-11ea-8a6b-a1c819d2e4f3.png)


before

```
$ node index.js fetch --prune origin
From https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit#gid=412014494
* [new branch]		master		-> origin/master
* [new branch]		develop		-> origin/develop
* [new branch]		dev-1		-> origin/dev-1
* [new branch]		test		-> origin/test
- [deleted]		(none)		-> origin/HEAD
fatal: Couldn't find remote ref 'test'
```

after

```
$ node index.js fetch --prune origin
From https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit#gid=412014494
* [new branch]		dev-1		-> origin/dev-1
* [new branch]		develop		-> origin/develop
* [new branch]		master		-> origin/master
- [deleted]		(none)		-> origin/HEAD
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.44s)

Test Suites: 11 passed, 11 total
Tests:       132 passed, 132 total
Snapshots:   0 total
Time:        5.915s, estimated 6s
Ran all test suites.
```