### PR TITLE
Fix die

### DIFF
--- a/src/main/__tests__/Clasp.spec.js
+++ b/src/main/__tests__/Clasp.spec.js
@@ -78,7 +78,7 @@ describe('Clasp', () => {
         expect(() => model.update()).toThrow('process.exit() was called.');
         expect(console.error).toHaveBeenCalledTimes(1)
         // must be calls[0] but bug
-        expect(console.error.mock.calls[0][0]).toEqual(["Don't exists local repo: test/do_not_exist/.sit."])
+        expect(console.error.mock.calls[0]).toEqual(["Don't exists local repo: test/do_not_exist/.sit."])
         expect(process.exit).toHaveBeenCalledWith(1);
       })
     })

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -276,7 +276,7 @@ describe('SitRepo', () => {
           });
 
           expect(() => model.branch({ deleteBranch: 'master' })).toThrow('process.exit() was called.')
-          expect(console.error.mock.calls[0][0]).toEqual(["error: Cannot delete branch 'master' checked out"])
+          expect(console.error.mock.calls[0]).toEqual(["error: Cannot delete branch 'master' checked out"])
           expect(console.error).toHaveBeenCalledTimes(1)
         })
       })
@@ -320,7 +320,7 @@ describe('SitRepo', () => {
 
           expect(() => model.branch({ deleteBranch: 'master' })).toThrow('process.exit() was called.')
           expect(console.error).toHaveBeenCalledTimes(1)
-          expect(console.error.mock.calls[0][0]).toEqual(["error: Cannot delete branch 'master' checked out"])
+          expect(console.error.mock.calls[0]).toEqual(["error: Cannot delete branch 'master' checked out"])
         })
       })
     })
@@ -389,7 +389,7 @@ describe('SitRepo', () => {
 
           expect(() => model.checkout(null, null, { branch: 'develop' })).toThrow('process.exit() was called.')
           expect(console.error).toHaveBeenCalledTimes(1)
-          expect(console.error.mock.calls[0][0]).toEqual(["fatal: A branch named 'develop' already exists."])
+          expect(console.error.mock.calls[0]).toEqual(["fatal: A branch named 'develop' already exists."])
         })
       })
 
@@ -422,7 +422,7 @@ describe('SitRepo', () => {
 
           expect(() => model.checkout('typo_origin', 'test')).toThrow('process.exit() was called.')
           expect(console.error).toHaveBeenCalledTimes(1)
-          expect(console.error.mock.calls[0][0]).toEqual([`\
+          expect(console.error.mock.calls[0]).toEqual([`\
 fatal: 'typo_origin' does not appear to be a sit repository
 fatal: Could not read from remote repository.
 
@@ -522,7 +522,7 @@ Please make sure you have the correct access rights and the repository exists.`]
 
         expect(() => model.commit()).toThrow('process.exit() was called.')
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual(["Need message to commit"])
+        expect(console.error.mock.calls[0]).toEqual(["Need message to commit"])
       })
     })
   })
@@ -661,7 +661,7 @@ Please make sure you have the correct access rights and the repository exists.`]
         expect(mockModel__isExistFile.mock.calls[0]).toEqual(["MERGE_HEAD"])
 
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual(["fatal: There is no merge in progress (MERGE_HEAD missing)"])
+        expect(console.error.mock.calls[0]).toEqual(["fatal: There is no merge in progress (MERGE_HEAD missing)"])
       })
     })
 
@@ -713,7 +713,7 @@ Merge remote-tracking branch 'origin/test'
 
         expect(() => model.merge('origin', 'master')).toThrow('process.exit() was called.')
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual([`\
+        expect(console.error.mock.calls[0]).toEqual([`\
 error: Merging is not possible because you have unmerged files.
 hint: Fix them up in the work tree, and then use 'sit merge --continue'
 hint: as appropriate to mark resolution and make a commit.
@@ -751,7 +751,7 @@ fatal: Existing because of an unresolved conflict.`])
 
         expect(() => model.merge(null, null, { stat: true })).toThrow('process.exit() was called.')
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual([`\
+        expect(console.error.mock.calls[0]).toEqual([`\
 fatal: You have not concluded your merge (MERGE_HEAD exists)
 Please, commit your changes before you merge.`])
       })

--- a/src/main/__tests__/index.spec.js
+++ b/src/main/__tests__/index.spec.js
@@ -41,7 +41,7 @@ describe('sit', () => {
         expect(() => sit().Repo.fetch('typo_origin', 'master')).toThrow('process.exit() was called.');
         expect(console.error).toHaveBeenCalledTimes(1)
         // must be calls[0] but bug
-        expect(console.error.mock.calls[0][0]).toEqual([`\
+        expect(console.error.mock.calls[0]).toEqual([`\
 fatal: 'typo_origin' does not appear to be a sit repository
 fatal: Could not read from remote repository.
 
@@ -113,7 +113,7 @@ Please make sure you have the correct access rights and the repository exists.`]
 
         expect(() => sit().Repo.push('origin', 'master')).toThrow('process.exit() was called.')
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual([`\
+        expect(console.error.mock.calls[0]).toEqual([`\
 fatal: 'origin' does not appear to be a sit repository
 fatal: Could not read from remote repository.
 
@@ -152,7 +152,7 @@ Please make sure you have the correct access rights and the repository exists.`]
 
           expect(() => sit().Repo.push('origin', null)).toThrow('process.exit() was called.')
           expect(console.error).toHaveBeenCalledTimes(1)
-          expect(console.error.mock.calls[0][0]).toEqual(["branch is required"])
+          expect(console.error.mock.calls[0]).toEqual(["branch is required"])
         })
       })
     })
@@ -184,7 +184,7 @@ Please make sure you have the correct access rights and the repository exists.`]
 
             // do not called by bug.
             // expect(console.error).toHaveBeenCalledTimes(1)
-            // expect(console.error.mock.calls[0][0]).toEqual("fatal: destination path 'test/dist/test_data.csv' already exists and is not an empty directory")
+            // expect(console.error.mock.calls[0]).toEqual("fatal: destination path 'test/dist/test_data.csv' already exists and is not an empty directory")
           })
         })
 
@@ -227,7 +227,7 @@ Please make sure you have the correct access rights and the repository exists.`]
 
           expect(() => sit().Repo.clone('origin', null)).toThrow('process.exit() was called.')
           expect(console.error).toHaveBeenCalledTimes(1)
-          expect(console.error.mock.calls[0][0]).toEqual(["url is required"])
+          expect(console.error.mock.calls[0]).toEqual(["url is required"])
         })
       })
     })
@@ -241,7 +241,7 @@ Please make sure you have the correct access rights and the repository exists.`]
         expect(() => sit().Repo.clone(null, 'https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=0')).toThrow('process.exit() was called.')
 
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual(["repository is required"])
+        expect(console.error.mock.calls[0]).toEqual(["repository is required"])
       })
     })
   })
@@ -283,7 +283,7 @@ Please make sure you have the correct access rights and the repository exists.`]
 
         expect(() => sit().Repo.checkLocalRepo()).toThrow('process.exit() was called.')
         expect(console.error).toHaveBeenCalledTimes(1)
-        expect(console.error.mock.calls[0][0]).toEqual(["fatal: not a sit repository (or any of the parent directories): test/localRepo/.sit"])
+        expect(console.error.mock.calls[0]).toEqual(["fatal: not a sit repository (or any of the parent directories): test/localRepo/.sit"])
       })
     })
   })
@@ -417,25 +417,25 @@ Please make sure you have the correct access rights and the repository exists.`]
     })
   })
 
-    describe('Repo.remote', () => {
-      it('should return correctly', () => {
-        const mockSitRepo_remote = jest.fn()
-        SitRepo.prototype.remote = mockSitRepo_remote
-        sit().Repo.remote('add', 'origin', 'https://test.co.jp')
+  describe('Repo.remote', () => {
+    it('should return correctly', () => {
+      const mockSitRepo_remote = jest.fn()
+      SitRepo.prototype.remote = mockSitRepo_remote
+      sit().Repo.remote('add', 'origin', 'https://test.co.jp')
 
-        expect(mockSitRepo_remote).toHaveBeenCalledTimes(1)
-        expect(mockSitRepo_remote.mock.calls[0]).toEqual(["add", "origin", "https://test.co.jp", {}])
-      })
+      expect(mockSitRepo_remote).toHaveBeenCalledTimes(1)
+      expect(mockSitRepo_remote.mock.calls[0]).toEqual(["add", "origin", "https://test.co.jp", {}])
     })
+  })
 
-    describe('Clasp.update', () => {
-      it('should return correctly', () => {
-        const mockClasp_update = jest.fn()
-        Clasp.prototype.update = mockClasp_update
-        sit().Clasp.update()
+  describe('Clasp.update', () => {
+    it('should return correctly', () => {
+      const mockClasp_update = jest.fn()
+      Clasp.prototype.update = mockClasp_update
+      sit().Clasp.update()
 
-        expect(mockClasp_update).toHaveBeenCalledTimes(1)
-        expect(mockClasp_update.mock.calls[0]).toEqual([])
-      })
+      expect(mockClasp_update).toHaveBeenCalledTimes(1)
+      expect(mockClasp_update.mock.calls[0]).toEqual([])
     })
+  })
 })

--- a/src/main/utils/global.js
+++ b/src/main/utils/global.js
@@ -1,4 +1,8 @@
 global.die = function (...args) {
-  console.error(args)
+  if (args.length > 1) {
+    console.error(args.join(','))
+  } else {
+    console.error(args[0])
+  }
   process.exit(1)
 }


### PR DESCRIPTION
## Summary

Fix die

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:57228) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:57228) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:57228) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
(node:57227) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:57227) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:57227) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.197s)

Test Suites: 11 passed, 11 total
Tests:       134 passed, 134 total
Snapshots:   0 total
Time:        5.64s, estimated 6s
Ran all test suites.
```