### PR TITLE
Fix error when sit clone that do not exist dist file (Fix #70)

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -18,7 +18,9 @@ const {
   mTimeMs,
   rmDirSync,
   fileBasename,
-  pathRelative
+  pathRelative,
+  pathDirname,
+  mkdirSyncRecursive
 } = require('./utils/file');
 
 const {
@@ -82,6 +84,10 @@ class SitRepo extends SitBaseRepo {
       ._writeLog("logs/HEAD", this._INITIAL_HASH(), masterHash, `clone: from ${url}`);
 
     // STEP 7: Update dist file instead of Update index
+    const distDir = pathDirname(this.distFilePath)
+    if (!isExistFile(distDir)) {
+      mkdirSyncRecursive(distDir)
+    }
     writeSyncFile(this.distFilePath, masterData);
   }
 


### PR DESCRIPTION
## Summary

Fix #70 

__before__

```
$ time node index.js clone origin https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit\#gid\=412014494
update files: ./.sit/scripts/clasp
ENOENT: no such file or directory, open 'dist/master_data.csv'
node index.js clone origin   0.30s user 0.15s system 11% cpu 4.001 total
```

__after__

```
$ time node index.js clone origin https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit\#gid\=412014494
update files: ./.sit/scripts/clasp
Cloning into ... 'dist/master_data.csv'
remote: Total 1
remote: done.
node index.js clone origin   0.28s user 0.15s system 13% cpu 3.182 total
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:64489) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:64489) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:64489) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
(node:64488) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:64488) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:64488) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js

Test Suites: 11 passed, 11 total
Tests:       135 passed, 135 total
Snapshots:   0 total
Time:        5.017s
Ran all test suites.
```