### PR TITLE
Create dist file when sit init

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -34,7 +34,9 @@ const SitConfig = require('./repos/SitConfig');
 const SitRefParser = require('./repos/refs/SitRefParser');
 
 class SitRepo extends SitBaseRepo {
-  init() {
+  init(opts = {}) {
+    const { data } = opts;
+
     if (isExistFile(this.localRepo)) {
       return false
     } else {
@@ -48,6 +50,9 @@ class SitRepo extends SitBaseRepo {
         ._writeSyncFile("config", "", true);
 
       writeSyncFile(`${this.homeDir}/.sitconfig`, "", true);
+
+      // Create distFile
+      this._createDistFile(data)
 
       return true
     }
@@ -84,11 +89,7 @@ class SitRepo extends SitBaseRepo {
       ._writeLog("logs/HEAD", this._INITIAL_HASH(), masterHash, `clone: from ${url}`);
 
     // STEP 7: Update dist file instead of Update index
-    const distDir = pathDirname(this.distFilePath)
-    if (!isExistFile(distDir)) {
-      mkdirSyncRecursive(distDir)
-    }
-    writeSyncFile(this.distFilePath, masterData);
+    this._createDistFile(masterData, true)
   }
 
   isLocalRepo() {

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -51,7 +51,10 @@ describe('SitRepo', () => {
         model.localRepo = 'test/sandbox/.sit'
         const mockModel__mkdirSyncRecursive = jest.spyOn(model, '_mkdirSyncRecursive').mockReturnValue(model)
         const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
-        expect(model.init()).toEqual(true)
+        const mockModel__createDistFile = jest.spyOn(model, '_createDistFile').mockReturnValueOnce(true)
+        const data = ['日本語', '英語', 'キー']
+        expect(model.init({ data })).toEqual(true)
+
         expect(mockModel__mkdirSyncRecursive).toHaveBeenCalledTimes(6)
         expect(mockModel__mkdirSyncRecursive.mock.calls[0]).toEqual([])
         expect(mockModel__mkdirSyncRecursive.mock.calls[1]).toEqual(['refs/heads'])
@@ -66,6 +69,9 @@ describe('SitRepo', () => {
 
         expect(writeSyncFile).toHaveBeenCalledTimes(1)
         expect(writeSyncFile.mock.calls[0]).toEqual(["./test/homeDir/.sitconfig", "", true])
+
+        expect(mockModel__createDistFile).toHaveBeenCalledTimes(1)
+        expect(mockModel__createDistFile.mock.calls[0]).toEqual([["日本語", "英語", "キー"]])
       })
     })
   })
@@ -98,6 +104,7 @@ describe('SitRepo', () => {
         model.localRepo = 'test/sandbox/.sit'
         const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
         const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
+        const mockModel__createDistFile = jest.spyOn(model, '_createDistFile').mockReturnValueOnce(true)
         const mockSitConfig_updateSection = jest.fn()
         SitConfig.prototype.updateSection = mockSitConfig_updateSection
 
@@ -105,7 +112,10 @@ describe('SitRepo', () => {
           'origin',
           'https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=0',
           '953b3794394d6b48d8690bc5e53aa2ffe2133035',
-          '日本語,英語,キー\nこんにちは,hello,greeting.hello\nさようなら,good_bye,greeting.good_bye\n歓迎します,wellcome,greeting.welcome\nおやすみ,good night,greeting.good_night',
+          [
+            ['日本語', '英語', 'キー'],
+            ['こんにちは', 'hello', 'greetiing.hello']
+          ],
           { type: 'GoogleSpreadSheet' }
         )
         expect(mockSitConfig_updateSection).toHaveBeenCalledTimes(2)
@@ -128,9 +138,12 @@ describe('SitRepo', () => {
         expect(mockModel__writeLog.mock.calls[2][0]).toBe('logs/HEAD')
         expect(mockModel__writeLog.mock.calls[2]).toEqual(["logs/HEAD", "0000000000000000000000000000000000000000", "953b3794394d6b48d8690bc5e53aa2ffe2133035", "clone: from https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=0"])
 
-        expect(writeSyncFile).toHaveBeenCalledTimes(1)
-        expect(writeSyncFile.mock.calls[0][0]).toBe('test/dist/test_data.csv')
-        expect(writeSyncFile.mock.calls[0][1]).toBe('日本語,英語,キー\nこんにちは,hello,greeting.hello\nさようなら,good_bye,greeting.good_bye\n歓迎します,wellcome,greeting.welcome\nおやすみ,good night,greeting.good_night')
+        expect(mockModel__createDistFile).toHaveBeenCalledTimes(1)
+        expect(mockModel__createDistFile.mock.calls[0][0]).toEqual([
+          ['日本語', '英語', 'キー'],
+          ['こんにちは', 'hello', 'greetiing.hello']
+        ])
+        expect(mockModel__createDistFile.mock.calls[0][1]).toEqual(true)
       })
     })
 

--- a/src/main/__tests__/index.spec.js
+++ b/src/main/__tests__/index.spec.js
@@ -13,12 +13,14 @@ const mockSitRepo_rollback = jest.fn()
 const mockGSS_getRows = jest.fn()
 const mockGSS_pushRows = jest.fn()
 const mockGSS_getSheetNames = jest.fn()
+const mockGSS_header = jest.fn()
 jest.mock('@main/sheets/GSS', () => {
   return jest.fn().mockImplementation(() => {
     return {
       getRows: mockGSS_getRows,
       pushRows: mockGSS_pushRows,
-      getSheetNames: mockGSS_getSheetNames
+      getSheetNames: mockGSS_getSheetNames,
+      header: mockGSS_header
     }
   })
 });
@@ -251,6 +253,7 @@ Please make sure you have the correct access rights and the repository exists.`]
       it('should return correctly', () => {
         SitRepo.prototype.init = mockSitRepo_init
         mockSitRepo_init.mockReturnValueOnce(false)
+        mockGSS_header.mockReturnValueOnce(['日本語', '英語', 'キー'])
         console.log = jest.fn()
         sit().Repo.init()
 
@@ -262,11 +265,13 @@ Please make sure you have the correct access rights and the repository exists.`]
     describe('when localRepo do not exist', () => {
       SitRepo.prototype.init = mockSitRepo_init
       mockSitRepo_init.mockReturnValueOnce(true)
+      mockGSS_header.mockReturnValueOnce(['日本語', '英語', 'キー'])
       console.log = jest.fn()
       sit().Repo.init()
 
-      expect(console.log).toHaveBeenCalledTimes(1)
+      expect(console.log).toHaveBeenCalledTimes(2)
       expect(console.log.mock.calls[0]).toEqual(["created local repo: test/localRepo/.sit"])
+      expect(console.log.mock.calls[1]).toEqual(["created dist file: test/dist/test_data.csv"])
     })
   })
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -210,7 +210,7 @@ To ${repo.remoteRepo(repoName)}\n\
               let sha = repo.hashObjectFromData(`${data.join('\n')}\n`, { type: 'blob', write: true });
 
               // Update local repo
-              repo.clone(repoName, url, sha, data.join('\n'), opts);
+              repo.clone(repoName, url, sha, data, opts);
 
               console.log(`\
 Cloning into ... '${repo.distFilePath}'\n\
@@ -236,9 +236,11 @@ remote: done.`);
   }
 
   Repo.init = () => {
-    const result = repo.init();
+    const data = sheet.header()
+    const result = repo.init({ data });
     if (result) {
       console.log(`created local repo: ${repo.localRepo}`);
+      console.log(`created dist file: ${repo.distFilePath}`);
       return
     } else {
       console.log(`already exist local repo: ${repo.localRepo}`);

--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -45,6 +45,20 @@ class SitBaseRepo extends SitBase {
     }
   }
 
+  _createDistFile(data, write = false) {
+    // STEP 7: Update dist file instead of Update index
+    const distDir = pathDirname(this.distFilePath)
+    if (!isExistFile(distDir)) {
+      mkdirSyncRecursive(distDir)
+    }
+    if (!isExistFile(this.distFilePath)) {
+      writeSyncFile(this.distFilePath, data);
+    }
+    if (write) {
+      writeSyncFile(this.distFilePath, data)
+    }
+  }
+
   _refCSVData(branch, repoName) {
     let refPath
 

--- a/src/main/sheets/GSS.js
+++ b/src/main/sheets/GSS.js
@@ -59,7 +59,7 @@ class GSS {
 
         let acc = await pacc
 
-        if (isEqual(sheet.headerValues, this._header())) {
+        if (isEqual(sheet.headerValues, this.header())) {
           acc.push(sheet._rawProperties.title)
         }
         return acc
@@ -70,7 +70,7 @@ class GSS {
     })
   }
 
-  getRows(repoName, sheetName, header = this._header()) {
+  getRows(repoName, sheetName, header = this.header()) {
     return new Promise((resolve, reject) => {
       this.loadInfo(repoName, (_, sheets) => {
         const sheet = sheets.filter(sheet => sheet._rawProperties.title == sheetName)[0]
@@ -141,7 +141,16 @@ class GSS {
     });
   }
 
-  _rows2CSV(rows, header = this._header()) {
+  header() {
+    const sheetSchema = SitSetting.sheet.gss.openAPIV3Schema.properties;
+    const keys = Object.keys(sheetSchema)
+    const result = keys.map(key => {
+      return sheetSchema[key]['description']
+    });
+    return result;
+  }
+
+  _rows2CSV(rows, header = this.header()) {
     let result = [];
 
     rows.forEach(row => {
@@ -190,15 +199,6 @@ class GSS {
     }
 
     await sheet.saveUpdatedCells();
-  }
-
-  _header() {
-    const sheetSchema = SitSetting.sheet.gss.openAPIV3Schema.properties;
-    const keys = Object.keys(sheetSchema)
-    const result = keys.map(key => {
-      return sheetSchema[key]['description']
-    });
-    return result;
   }
 }
 


### PR DESCRIPTION
## Summary

- Modify sit clone
- Modify sit init

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:21737) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:21737) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:21737) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
(node:21736) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:21736) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:21736) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.108s)

Test Suites: 11 passed, 11 total
Tests:       135 passed, 135 total
Snapshots:   0 total
Time:        6.552s
Ran all test suites.
```