### PR TITLE
Upgrade sit checkout: check valid branch name

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -18,9 +18,7 @@ const {
   mTimeMs,
   rmDirSync,
   fileBasename,
-  pathRelative,
-  pathDirname,
-  mkdirSyncRecursive
+  pathRelative
 } = require('./utils/file');
 
 const {
@@ -32,6 +30,7 @@ const editor = require('./utils/editor');
 const SitBaseRepo = require('./repos/base/SitBaseRepo');
 const SitConfig = require('./repos/SitConfig');
 const SitRefParser = require('./repos/refs/SitRefParser');
+const SitRepoValidator = require('./repos/validators/SitRepoValidator');
 
 class SitRepo extends SitBaseRepo {
   init(opts = {}) {
@@ -274,6 +273,13 @@ Please make sure you have the correct access rights and the repository exists.`)
         .checkout(null, name);
 
     } else if (branch) {
+      const validator = new SitRepoValidator()
+
+      if (!validator.isBranch(branch)) {
+        const err = validator.errors[0]
+        die(err.message)
+      }
+
       const fullCurrentRefPath = this._getPath(`refs/heads/${branch}`);
 
       if (isExistFile(fullCurrentRefPath)) {

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -432,22 +432,38 @@ describe('SitRepo', () => {
       })
 
       describe('when checkout branch is new branch', () => {
-        it('should return correctly', () => {
-          console.log = jest.fn()
-          const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
-          const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
-          model.checkout(null, null, { branch: 'new_branch' })
+        describe('when branch name is valid', () => {
+          it('should return correctly', () => {
+            console.log = jest.fn()
+            const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
+            const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
 
-          expect(mockModel__writeSyncFile).toHaveBeenCalledTimes(2)
-          expect(mockModel__writeSyncFile.mock.calls[0]).toEqual(["HEAD", "ref: refs/heads/new_branch", false])
-          expect(mockModel__writeSyncFile.mock.calls[1]).toEqual(["refs/heads/new_branch", "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", false])
+            model.checkout(null, null, { branch: 'new_branch' })
 
-          expect(mockModel__writeLog).toHaveBeenCalledTimes(2)
-          expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/HEAD", "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", "checkout: moving from master to new_branch"])
-          expect(mockModel__writeLog.mock.calls[1]).toEqual(["logs/refs/heads/new_branch", null, "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", "branch: Created from HEAD"])
+            expect(mockModel__writeSyncFile).toHaveBeenCalledTimes(2)
+            expect(mockModel__writeSyncFile.mock.calls[0]).toEqual(["HEAD", "ref: refs/heads/new_branch", false])
+            expect(mockModel__writeSyncFile.mock.calls[1]).toEqual(["refs/heads/new_branch", "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", false])
 
-          expect(console.log).toHaveBeenCalledTimes(1)
-          expect(console.log.mock.calls[0]).toEqual(["Switched to a new branch 'new_branch'"])
+            expect(mockModel__writeLog).toHaveBeenCalledTimes(2)
+            expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/HEAD", "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", "checkout: moving from master to new_branch"])
+            expect(mockModel__writeLog.mock.calls[1]).toEqual(["logs/refs/heads/new_branch", null, "0133e12ee3679cb5bd494cb50e4f5a5a896eeb14", "branch: Created from HEAD"])
+
+            expect(console.log).toHaveBeenCalledTimes(1)
+            expect(console.log.mock.calls[0]).toEqual(["Switched to a new branch 'new_branch'"])
+          })
+        })
+
+        describe('when branch name is invalid', () => {
+          it('should return correctly', () => {
+            console.error = jest.fn()
+            jest.spyOn(process, 'exit').mockImplementation(() => {
+              throw new Error('process.exit() was called.')
+            });
+
+            expect(() => model.checkout(null, null, { branch: '[pr] master...develop' })).toThrow('process.exit() was called.')
+            expect(console.error).toHaveBeenCalledTimes(1)
+            expect(console.error.mock.calls[0]).toEqual(["fatal: '[pr] master...develop' is not a valid branch name."])
+          })
         })
       })
 

--- a/src/main/repos/validators/SitRepoValidator.js
+++ b/src/main/repos/validators/SitRepoValidator.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const SitBase = require('../base/SitBase');
+const PROHIBITED_STR_REGEXP = /[\^,@,\0,!,?,*]/
+const RESERVED_RESERVED_BRANCH_PREFIX = '[pr]'
+const RESERVED_BRANCH = [
+  'refs/remotes',
+  'logs/refs/remotes'
+]
+
+class SitRepoValidator extends SitBase {
+
+  constructor(opts) {
+    super(opts)
+    this.errors = []
+  }
+
+  isBranch(branch) {
+    const pattern = new RegExp(PROHIBITED_STR_REGEXP)
+    const includeInvalidStr = pattern.test(branch)
+    const includeReservedBranch = RESERVED_BRANCH.indexOf(branch) !== -1
+    const includeReservedBranchPrefix = branch.startsWith(RESERVED_RESERVED_BRANCH_PREFIX)
+
+    if (includeInvalidStr || includeReservedBranch || includeReservedBranchPrefix) {
+      this.errors.push(new Error(`fatal: '${branch}' is not a valid branch name.`))
+      return false
+    } else {
+      return true
+    }
+  }
+}
+
+module.exports = SitRepoValidator;

--- a/src/main/repos/validators/__tests__/SitRepoValidator.spec.js
+++ b/src/main/repos/validators/__tests__/SitRepoValidator.spec.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const SitRepoValidator = require('@repos/validators/SitRepoValidator');
+
+describe('SitRepoValidator', () => {
+  const validator = new SitRepoValidator()
+
+  beforeEach(() => {
+    validator.errors = []
+  })
+
+  describe('#isBranch', () => {
+    describe('when brach include invalid str', () => {
+      it('should return correctly', () => {
+        const result = validator.isBranch("[pr]test^@\0!?*")
+
+        expect(result).toEqual(false)
+        expect(validator.errors[0].message).toEqual("fatal: '[pr]test^@\0!?*' is not a valid branch name.")
+      })
+    })
+
+    describe('when branch include reserved branch(refs/remotes)', () => {
+      it('should return correctly', () => {
+        const result = validator.isBranch("refs/remotes")
+
+        expect(result).toEqual(false)
+        expect(validator.errors[0].message).toEqual("fatal: 'refs/remotes' is not a valid branch name.")
+      })
+    })
+
+    describe('when branch include reserved branch(logs/refs/remotes)', () => {
+      it('should return correctly', () => {
+        const result = validator.isBranch("logs/refs/remotes")
+
+        expect(result).toEqual(false)
+        expect(validator.errors[0].message).toEqual("fatal: 'logs/refs/remotes' is not a valid branch name.")
+      })
+    })
+
+    describe('when branch name is valid', () => {
+      it('should return correctly', () => {
+        const result = validator.isBranch("new_branch")
+
+        expect(result).toEqual(true)
+        expect(validator.errors.length).toEqual(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fix #65 

## Work

```
$ node index.js checkout -b "[pr] test"
fatal: '[pr] test' is not a valid branch name.
```

```
$ node index.js checkout -b "hoge/fuga^bar"
fatal: 'hoge/fuga^bar' is not a valid branch name.
```

```
$ node index.js checkout -b "test^@?"
fatal: 'test^@?' is not a valid branch name.
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:47774) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:47774) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:47774) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
(node:47773) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:47773) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:47773) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js

Test Suites: 12 passed, 12 total
Tests:       140 passed, 140 total
Snapshots:   0 total
Time:        5.563s, estimated 6s
Ran all test suites.
```