### PR TITLE
Modify SitBaseRepo#_objectRead

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -130,11 +130,9 @@ class SitRepo extends SitBaseRepo {
     return new Promise((resolve, reject) => {
       this._objectFind(name)
         .then(sha => {
-          this._objectRead(sha)
-            .then(obj => {
-              resolve(obj);
-            })
-            .catch(err => reject(err));
+          const { err, obj } = this._objectRead(sha)
+          if (err) reject(err)
+          resolve(obj)
         })
         .catch(err => reject(err));
     })

--- a/src/main/repos/base/__tests__/SitBaseRepo.spec.js
+++ b/src/main/repos/base/__tests__/SitBaseRepo.spec.js
@@ -245,24 +245,22 @@ describe('SitBaseRepo', () => {
   describe('#_objectRead', () => {
     describe('when sha exists', () => {
       const sha1 = '0133e12ee3679cb5bd494cb50e4f5a5a896eeb14';
-      it('should return correctly', (done) => {
-        model._objectRead(sha1).then(obj => {
-          expect(obj.serialize().toString()).toEqual(`\
+      it('should return correctly', () => {
+        const { err, obj } = model._objectRead(sha1)
+        expect(obj.serialize().toString()).toEqual(`\
 日本語,英語,キー
 こんにちは,hello,greeting.hello
 `)
-          done()
-        })
+        expect(err).toBeNull()
       })
     })
 
     describe('when sha do not exists', () => {
       const gocha = 'not_exists'
-      it('should return correctly', (done) => {
-        model._objectRead(gocha).catch(err => {
-          expect(err.message).toEqual('Do not exists path: undefined')
-          done()
-        })
+      it('should return correctly', () => {
+        const { err, obj } = model._objectRead(gocha)
+        expect(obj).toBeNull()
+        expect(err.message).toEqual('Do not exists path: undefined')
       })
     })
   })


### PR DESCRIPTION
## Summary

Modify SitBaseRepo#_objectRead

## Work

```
$ node index.js push origin dev-2
Writed objects: 100% (1/1)
Total 1
remote:
remote: Create a pull request for dev-2 on GoogleSpreadSheet by visiting:
remote:     https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit#gid=2010045482
remote:
To https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit#gid=2010045482
	7a7e06a..71cce4b  dev-2 -> dev-2
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:28630) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:28630) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:28630) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.744s)
(node:28629) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:28629) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:28629) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

Test Suites: 12 passed, 12 total
Tests:       140 passed, 140 total
Snapshots:   0 total
Time:        6.251s
Ran all test suites.
```