### PR TITLE
Fix SitBaseRepo#_objectRead

### DIFF
--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -281,6 +281,7 @@ class SitBaseRepo extends SitBase {
 
     if (size != (binary.length - y - 2)) {
       err = new Error(`Malformed object ${sha}: bad length.`)
+      return { err, obj }
     }
 
     // Pick constructor


### PR DESCRIPTION
## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:30522) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:30522) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:30522) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.06s)
(node:30521) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:30521) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:30521) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

Test Suites: 12 passed, 12 total
Tests:       140 passed, 140 total
Snapshots:   0 total
Time:        6.796s
Ran all test suites.
(⎈ |minikube:default)#2
```