### PR TITLE
Fix bug when sit checkout origin do_not_exist_branch

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -269,7 +269,14 @@ Please make sure you have the correct access rights and the repository exists.`)
       }
       // checkout local from remote
     } else if (!branch && isRemote) {
-      const branchHash = this._refResolve(`refs/remotes/${repoName}/${name}`);
+      const refRemotePath = `refs/remotes/${repoName}/${name}`
+
+      if (!this._isExistFile(refRemotePath)) {
+        const err = new Error(`error: pathspec '${name}' did not match any file(s) known to sit`)
+        die(err.message)
+      }
+
+      const branchHash = this._refResolve(refRemotePath);
 
       const config = new SitConfig('local');
       config.updateSection(`branch.${name}`, { remote: repoName, merge: `refs/heads/${name}` });

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -428,27 +428,43 @@ Merge from GoogleSpreadSheet/develop`
     })
 
     describe('when checkout from remote branch', () => {
-      it('should return correctly', () => {
-        const mockSitConfig_updateSection = jest.fn()
-        SitConfig.prototype.updateSection = mockSitConfig_updateSection
-        const mockModel__fileCopySync = jest.spyOn(model, '_fileCopySync').mockReturnValue(model)
-        const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
-        const mockModel__objectFind = jest.spyOn(model, '_objectFind').mockReturnValueOnce(Promise.resolve('b18c9566daeb03818f64109ffcd9c8ad545b5f6e'))
-        model.checkout('origin', 'test', {})
+      describe('when remote branch exists', () => {
+        it('should return correctly', () => {
+          const mockSitConfig_updateSection = jest.fn()
+          SitConfig.prototype.updateSection = mockSitConfig_updateSection
+          const mockModel__fileCopySync = jest.spyOn(model, '_fileCopySync').mockReturnValue(model)
+          const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
+          const mockModel__objectFind = jest.spyOn(model, '_objectFind').mockReturnValueOnce(Promise.resolve('b18c9566daeb03818f64109ffcd9c8ad545b5f6e'))
+          model.checkout('origin', 'test', {})
 
-        expect(mockSitConfig_updateSection).toHaveBeenCalledTimes(1)
-        expect(mockSitConfig_updateSection.mock.calls[0]).toEqual(["branch.test", { "merge": "refs/heads/test", "remote": "origin" }])
+          expect(mockSitConfig_updateSection).toHaveBeenCalledTimes(1)
+          expect(mockSitConfig_updateSection.mock.calls[0]).toEqual(["branch.test", { "merge": "refs/heads/test", "remote": "origin" }])
 
-        expect(mockModel__fileCopySync).toHaveBeenCalledTimes(1)
-        expect(mockModel__fileCopySync.mock.calls[0]).toEqual(["refs/remotes/origin/test", "refs/heads/test"])
+          expect(mockModel__fileCopySync).toHaveBeenCalledTimes(1)
+          expect(mockModel__fileCopySync.mock.calls[0]).toEqual(["refs/remotes/origin/test", "refs/heads/test"])
 
-        expect(mockModel__writeLog).toHaveBeenCalledTimes(1)
-        expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/refs/heads/test", null, "b18c9566daeb03818f64109ffcd9c8ad545b5f6e", "branch: Created from refs/remotes/origin/test"])
+          expect(mockModel__writeLog).toHaveBeenCalledTimes(1)
+          expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/refs/heads/test", null, "b18c9566daeb03818f64109ffcd9c8ad545b5f6e", "branch: Created from refs/remotes/origin/test"])
 
-        // checkout test (2 times)
+          // checkout test (2 times)
 
-        expect(mockModel__objectFind).toHaveBeenCalledTimes(1)
-        expect(mockModel__objectFind.mock.calls[0]).toEqual(["test"])
+          expect(mockModel__objectFind).toHaveBeenCalledTimes(1)
+          expect(mockModel__objectFind.mock.calls[0]).toEqual(["test"])
+        })
+      })
+
+      describe('when remote branch do not exists', () => {
+        it('should return correctly', () => {
+          const mockModel__isExistFile = jest.spyOn(model, '_isExistFile').mockReturnValueOnce(false)
+          console.error = jest.fn()
+          jest.spyOn(process, 'exit').mockImplementation(() => {
+            throw new Error('process.exit() was called.')
+          });
+
+          expect(() => model.checkout('origin', 'do_not_exist', {})).toThrow('process.exit() was called.')
+          expect(console.error).toHaveBeenCalledTimes(1)
+          expect(console.error.mock.calls[0]).toEqual(["error: pathspec 'do_not_exist' did not match any file(s) known to sit"])
+        })
       })
     })
 


### PR DESCRIPTION
## Summary

Fix #95 

## Work

```
$ node index.js checkout origin hoge
error: pathspec 'hoge' did not match any file(s) known to sit
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

(node:73141) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:73141) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:73141) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:73141) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:73141) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
(node:73139) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:73139) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:73139) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:73139) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:73139) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (7.26s)

Test Suites: 13 passed, 13 total
Tests:       151 passed, 151 total
Snapshots:   0 total
Time:        7.779s
Ran all test suites.
```