### PR TITLE
Implement: sit branch -m <new_branch>

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,10 @@ program
     '-D, --deleteBranch <deleteBranch>',
     'delete branch'
   )
+  .option(
+    '-m, --moveBranch <moveBranch>',
+    'move/rename a branch and its reflog'
+  )
   .action(options => {
     sit().Repo.branch(options);
   });

--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -154,7 +154,7 @@ class SitRepo extends SitBaseRepo {
   }
 
   branch(opts = {}) {
-    const { all, deleteBranch } = opts;
+    const { all, deleteBranch, moveBranch } = opts;
     const currentBranch = this._branchResolve('HEAD');
     let fullBranchDirPath;
 
@@ -177,6 +177,22 @@ class SitRepo extends SitBaseRepo {
           return
         });
       }
+
+    } else if (moveBranch) {
+      const currentHash = this._refResolve('HEAD')
+
+      // STEP 1: Copy from refs/heads/<currentBranch> to refs/heads/<moveBranch>
+      // STEP 2: Copy from logs/refs/heads/<currentBranch> to logs/reefs/heads/<moveBranch>
+      // STEP 3: Write logs/HEAD
+      // STEP 4: Update HEAD
+      // STEP 5: Delete refs/heads/<currentBranch>
+      // STEP 6: Delete logs/refs/heads/<currentBranch>
+      this._fileCopySync(`refs/heads/${currentBranch}`, `refs/heads/${moveBranch}`)
+        ._fileCopySync(`logs/refs/heads/${currentBranch}`, `logs/refs/heads/${moveBranch}`)
+        ._writeLog("logs/HEAD", currentHash, currentHash, `Branch: renamed refs/heads/origin to refs/heads/${moveBranch}`)
+        ._writeSyncFile(`HEAD`, `ref: refs/heads/${moveBranch}`, false)
+        ._deleteSyncFile(`refs/heads/${currentBranch}`)
+        ._deleteSyncFile(`logs/refs/heads/${currentBranch}`)
 
     } else {
 

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -387,6 +387,30 @@ describe('SitRepo', () => {
         })
       })
     })
+
+    describe("when specify 'moveBranch' option", () => {
+      it("should return correctly", () => {
+        const mockModel__fileCopySync = jest.spyOn(model, '_fileCopySync').mockReturnValue(model)
+        const mockModel__writeLog = jest.spyOn(model, '_writeLog').mockReturnValue(model)
+        const mockModel__writeSyncFile = jest.spyOn(model, '_writeSyncFile').mockReturnValue(model)
+        const mockModel__deleteSyncFile = jest.spyOn(model, '_deleteSyncFile').mockReturnValue(model)
+
+        model.branch({ moveBranch: 'new_branch' })
+        expect(mockModel__fileCopySync).toHaveBeenCalledTimes(2)
+        expect(mockModel__fileCopySync.mock.calls[0]).toEqual(["refs/heads/master", "refs/heads/new_branch"])
+        expect(mockModel__fileCopySync.mock.calls[1]).toEqual(["logs/refs/heads/master", "logs/refs/heads/new_branch"])
+
+        expect(mockModel__writeLog).toHaveBeenCalledTimes(1)
+        expect(mockModel__writeLog.mock.calls[0]).toEqual(["logs/HEAD", "03577e30b394d4cafbbec22cc1a78b91b3e7c20b", "03577e30b394d4cafbbec22cc1a78b91b3e7c20b", "Branch: renamed refs/heads/origin to refs/heads/new_branch"])
+
+        expect(mockModel__writeSyncFile).toHaveBeenCalledTimes(1)
+        expect(mockModel__writeSyncFile.mock.calls[0]).toEqual(["HEAD", "ref: refs/heads/new_branch", false])
+
+        expect(mockModel__deleteSyncFile).toHaveBeenCalledTimes(2)
+        expect(mockModel__deleteSyncFile.mock.calls[0]).toEqual(["refs/heads/master"])
+        expect(mockModel__deleteSyncFile.mock.calls[1]).toEqual(["logs/refs/heads/master"])
+      })
+    })
   })
 
   describe('#checkout', () => {


### PR DESCRIPTION
## Summary

#96 

## Work

```
$ node index branch -m develop
```

![image](https://user-images.githubusercontent.com/11146767/75687056-8f9bbf00-5ce0-11ea-8657-65fbe7485668.png)

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:24379) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:24379) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:24379) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:24379) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:24379) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.111s)
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
(node:24379) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:24379) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 6)
(node:24379) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:24379) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 7)
 PASS  src/main/__tests__/SitRepo.spec.js

Test Suites: 13 passed, 13 total
Tests:       155 passed, 155 total
Snapshots:   0 total
Time:        9.331s
Ran all test suites.
```