### PR TITLE
Fix sit cat-file -p

### DIFF
--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -502,7 +502,10 @@ class SitBaseRepo extends SitBase {
         }
 
         if (shaArr.length > 1) {
-          reject(new Error(`Ambigous reference ${name}: Cndidates are:\n - ${"\n-1".join(shaArr)}`));
+          reject(new Error(`Ambigous reference ${name}: Cndidates are:\n${shaArr.reduce((acc, item) => {
+            acc = acc + `- ${item}\n`
+            return acc
+          }, '').trim()}`));
         }
 
         let sha = shaArr[0];
@@ -563,7 +566,7 @@ class SitBaseRepo extends SitBase {
                 if (fileName.startsWith(rem)) {
                   return prefix + fileName
                 }
-              });
+              }).filter(v => v);
 
               if (candidates.length > 0) {
                 resolve(candidates);


### PR DESCRIPTION
## Summary

```
$ node index.js cat-file -p 1a66eae
"
-1".join is not a function
```

```
$ node index.js cat-file -p 1a66eae
blob fb078a443b611ebcde99f12a751caaba233a69f0
parent a59011ddf998935862253cb6690add50d533c5fa
author yukihirop <te108186@gmail.com> 1583329202892 +0900
committer yukihirop <te108186@gmail.com> 1583329202892 +0900

Update master data
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:36560) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:36560) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:36560) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
(node:36559) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:36559) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:36559) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:36559) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:36559) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.5s)

Test Suites: 13 passed, 13 total
Tests:       10 skipped, 168 passed, 178 total
Snapshots:   0 total
Time:        5.926s
Ran all test suites.
```