### PR TITLE
Support sit cat-file -p ORIG_HEAD・FETCH_HEAD・REMOTE_HEAD

### DIFF
--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -541,8 +541,14 @@ class SitBaseRepo extends SitBase {
         resolve(null)
       }
 
-      if (name == "HEAD") {
+      if (name === "HEAD") {
         resolve([this._refResolve("HEAD")])
+      } else if (name === "ORIG_HEAD") {
+        resolve([this._refResolve("ORIG_HEAD")])
+      } else if (name === "REMOTE_HEAD") {
+        resolve([this._refResolve("REMOTE_HEAD")])
+      } else if (name === "FETCH_HEAD") {
+        resolve([this._refResolve("FETCH_HEAD")])
       }
 
       if (name.match(hashRE)) {
@@ -600,6 +606,8 @@ class SitBaseRepo extends SitBase {
 
       if (data.startsWith("ref: ")) {
         return this._refResolve(data.slice(5));
+      } else if (ref === "FETCH_HEAD") {
+        return data.split('\t')[0];
       } else {
         return data;
       }


### PR DESCRIPTION
## Summary

Fix #108

#### ORIG_HEAD

```
$ node index.js cat-file -p ORIG_HEAD
blob fb078a443b611ebcde99f12a751caaba233a69f0
parent a59011ddf998935862253cb6690add50d533c5fa
author yukihirop <te108186@gmail.com> 1583329202892 +0900
committer yukihirop <te108186@gmail.com> 1583329202892 +0900

Update master data
```

#### FETCH_HEAD

```
$ node index.js cat-file -p FETCH_HEAD
blob 7a7e06a095e58d3ec710b37c6a566a34c5f955b9
parent 6e8e020be9e081daf6c3b37a9e8e5f3644d4d3b2
author yukihirop <te108186@gmail.com> 1583042753353 +0900
committer GoogleSpreadSheet <noreply@googlespreadsheet.com> 1583042753353 +0900

Merge from GoogleSpreadSheet/master
```

#### REMOTE_HEAD

```
$ node index.js cat-file -p REMOTE_HEAD
日本語,英語,キー
こんにちは,hello,common.greeting.hello
さようなら,goodbye,common.greeting.good_bye
おやすみなさい,good_night,common.greeting.good_night
バイバイ,bye bye,common.byebye
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:38771) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:38771) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:38771) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
(node:38770) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:38770) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:38770) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:38770) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:38770) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.707s)

Test Suites: 13 passed, 13 total
Tests:       10 skipped, 168 passed, 178 total
Snapshots:   0 total
Time:        6.225s
Ran all test suites.
```