### PR TITLE
Implement sit pull-request

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,6 +259,22 @@ program
   })
 
 program
+  .command('pull-request <repository> <args>')
+  .description('Create pull request in Sheet')
+  .option(
+    '-t, --type <type>',
+    'sheet type',
+    'GoogleSpreadSheet'
+  )
+  .option(
+    '-f, --force',
+    'override sheet'
+  )
+  .action((repository, args, options) => {
+    sit().Repo.pullRequest(repository, args, options)
+  })
+
+program
   .useSubcommand(initCmd)
   .useSubcommand(claspCmd)
   .useSubcommand(repoCmd)

--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -975,6 +975,40 @@ Dropped ${stashKey} (${stashCommitHash})`)
       })
     }
   }
+
+  createPullRequestData(toData, fromData, callback) {
+    this.__createtwoWayMergeData(toData, fromData, (result) => {
+      let header = result['0']['to'];
+      header.push('Index', 'Status');
+
+      delete result['0'];
+
+      const data = Object.values(result).reduce((acc, item, index) => {
+        if (item.conflict) {
+          if (item['to'] === null) {
+            item['from'].push(index, '+');
+            acc.push(item['from']);
+          } else {
+            if (item['from'] === null) {
+              item['to'].push(index, '±');
+              acc.push(item['to']);
+            } else {
+              item['to'].push(index, '-')
+              item['from'].push(index, '+');
+              acc.push(item['to']);
+              acc.push(item['from']);
+            }
+          }
+        } else {
+          item['to'].push(index, '');
+          acc.push(item['to']);
+        }
+        return acc;
+      }, [header]);
+
+      callback(data);
+    })
+  }
 }
 
 module.exports = SitRepo;

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -1361,4 +1361,63 @@ cc8aa255b845ffbac3ef18b0fce15f7e8bac7e46 refs/heads/develop
       })
     })
   })
+
+  describe('#createPullRequestData', () => {
+    describe('When some elements exist only in Hoge', () => {
+      it('should return correctly', () => {
+        const header = ['日本語', '英語', 'キー'];
+        const toData = [
+          header,
+          ['こんにちは', 'hello', 'common.greeting.hello'],
+          ['さようなら', 'goodbye', 'common.greeting.good_bye'],
+          ['おはよう', 'good morning', 'common.greeting.good_morning']
+        ];
+        const fromData = [
+          header,
+          ['こんにちは', 'hello', 'common.greeting.hello'],
+        ]
+        model.createPullRequestData(toData, fromData, (result) => {
+          expect(result).toEqual(
+            [
+              ["日本語", "英語", "キー", "Index", "Status"],
+              ["こんにちは", "hello", "common.greeting.hello", 0, ""],
+              ["さようなら", "goodbye", "common.greeting.good_bye", 1, "±"],
+              ["おはよう", "good morning", "common.greeting.good_morning", 2, "±"]
+            ]
+          )
+        })
+      })
+    })
+
+    describe('If there are corrections and additions', () => {
+      it('should return correctly', () => {
+        const header = ['日本語', '英語', 'キー'];
+        const toData = [
+          header,
+          ['こんにちは', 'hello', 'common.greeting.hello'],
+          ['さようなら', 'goodbye', 'common.greeting.good_bye'],
+          ['おはよう', 'good morning', 'common.greeting.good_morning']
+        ];
+        const fromData = [
+          header,
+          ['こんにちは', 'hello', 'common.greeting.hello'],
+          ['さようなら', 'goodbye', 'common.greeting.good_bye'],
+          ['バイバイ', 'bye bye', 'common.greeting.bye_bye'],
+          ['おやすみなさい', 'good night', 'common.greeting.good_night']
+        ]
+        model.createPullRequestData(toData, fromData, (result) => {
+          expect(result).toEqual(
+            [
+              ["日本語", "英語", "キー", "Index", "Status"],
+              ["こんにちは", "hello", "common.greeting.hello", 0, ""],
+              ["さようなら", "goodbye", "common.greeting.good_bye", 1, ""],
+              ["おはよう", "good morning", "common.greeting.good_morning", 2, "-"],
+              ["バイバイ", "bye bye", "common.greeting.bye_bye", 2, "+"],
+              ["おやすみなさい", "good night", "common.greeting.good_night", 3, "+"]
+            ]
+          )
+        })
+      })
+    })
+  })
 })

--- a/src/main/__tests__/index.spec.js
+++ b/src/main/__tests__/index.spec.js
@@ -433,6 +433,57 @@ Please make sure you have the correct access rights and the repository exists.`]
     })
   })
 
+  describe('Repo.pullRequest', () => {
+    describe('when bad syntax', () => {
+      it('should return correctly', () => {
+        console.error = jest.fn()
+        jest.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit() was called.')
+        });
+
+        expect(() => sit().Repo.pullRequest('origin', 'master_test')).toThrow('process.exit() was called.')
+        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error.mock.calls[0]).toEqual(["fatal: ambiguous argument 'master_test': unknown revision or path not in the working tree."])
+      })
+    })
+
+    describe('when remote branch (from branch) do not exist', () => {
+      it('should return correctly', () => {
+        console.error = jest.fn()
+        jest.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit() was called.')
+        });
+
+        expect(() => sit().Repo.pullRequest('origin', 'master...do_not_exist')).toThrow('process.exit() was called.')
+        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error.mock.calls[0]).toEqual(["error: pathspec 'origin/do_not_exist' did not match any file(s) known to sit"])
+      })
+    })
+
+    describe('when remote branch (to branch) do not exist', () => {
+      it('should return correctly', () => {
+        console.error = jest.fn()
+        jest.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit() was called.')
+        });
+
+        expect(() => sit().Repo.pullRequest('origin', 'do_not_exist...test')).toThrow('process.exit() was called.')
+        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error.mock.calls[0]).toEqual(["error: pathspec 'origin/do_not_exist' did not match any file(s) known to sit"])
+      })
+    })
+
+    describe('when pull request is success', () => {
+      it('should return correctly', () => {
+        mockGSS_getRows.mockReturnValueOnce(Promise.resolve([[], []]))
+        sit().Repo.pullRequest('origin', 'master...test')
+
+        expect(mockGSS_getRows).toHaveBeenCalledTimes(1)
+        expect(mockGSS_getRows.mock.calls[0]).toEqual(['origin', 'master'])
+      })
+    })
+  })
+
   describe('Clasp.update', () => {
     it('should return correctly', () => {
       const mockClasp_update = jest.fn()

--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -17,6 +17,10 @@ const {
   pathDirname
 } = require('../../utils/file');
 
+const {
+  isEqual
+} = require('../../utils/array');
+
 const SitSetting = require('../../SitSetting')
   , SitConfig = require('../SitConfig');
 
@@ -676,8 +680,7 @@ class SitBaseRepo extends SitBase {
       let toLine = toData.shift() || null;
       let fromLine = fromData.shift() || null;
 
-
-      if (toLine === fromLine) {
+      if (isEqual(toLine, fromLine)) {
         result[index] = { conflict: false, to: toLine, from: fromLine };
       } else {
         result[index] = { conflict: true, to: toLine, from: fromLine };


### PR DESCRIPTION
## Summary

#122 

Implement `sit pull-request`

## Work

#### success

```
$ node index.js pull-request origin dev-1...dev-3
Total 1
remote:
remote: Create a pull request for 'dev-1' from 'dev-3' on GoogleSpreadSheet by visiting:
remote:     https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit#gid=2010045482
remote:
To https://docs.google.com/spreadsheets/d/1tkNrlcDws5KlBzt8DVAU0Xu97tPHy9dIOHYZrT_YtPs/edit#gid=2010045482
	Please look at sheet: '[pr] dev-1...dev-3' in GoogleSpreadSheet
```

![image](https://user-images.githubusercontent.com/11146767/77180400-3370d180-6b0d-11ea-999a-2ec3b0f05e1d.png)


#### error

```
$ node index.js pull-request hoge dev-1...dev-3
error: pathspec 'hoge/dev-1' did not match any file(s) known to sit
```

#### errror

```
$ node index.js pull-request origin do_not_exist...dev-3
error: pathspec 'origin/do_not_exist' did not match any file(s) known to sit
```

#### error

```
$ node index.js pull-request origin dev-1....dev-3
error: pathspec 'origin/dev-1.' did not match any file(s) known to sit
```

#### fatal

```
$ node index.js pull-request origin dev-1_dev-3
fatal: ambiguous argument 'dev-1_dev-3': unknown revision or path not in the working tree.
```

## test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
(node:31348) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:31348) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:31348) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:31348) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:31348) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
(node:31347) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:31347) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:31347) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:31347) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:31347) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.905s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        6.356s, estimated 7s
Ran all test suites.
```