### PR TITLE
Fix sit status && sit diff

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -350,7 +350,8 @@ Please make sure you have the correct access rights and the repository exists.`)
 
       this.catFile(blobHash).then(obj => {
         const headStream = obj.serialize().toString();
-        const { err, data } = fileSafeLoad(this.distFilePath);
+        let { err, data } = fileSafeLoad(this.distFilePath);
+        data = data.trim()
 
         if (err) {
           die(err.message);
@@ -373,7 +374,7 @@ Please make sure you have the correct access rights and the repository exists.`)
     opts = Object.assign(opts, { type: 'blob' });
 
     const currentBranch = this._branchResolve('HEAD');
-    const currentHash = this._refResolve('HEAD');
+    const currentHash = this._refBlob('HEAD');
     const calculateHash = this.hashObject(this.distFilePath, opts);
 
     if (currentHash !== calculateHash) {


### PR DESCRIPTION
## Summary

- Fix `sit status` and `sit diff`
- Fix #128 

## Work

#### sit status

```
$ node index.js status
On branch develop
nothing to commit

$ node index.js status
On branch develop

	modified: dist/master_data.csv

no changes added to commit
```

#### sit diff

```
$ node index.js diff
```

```
$ node index.js diff
Index: be50bef..8f2caa2
===================================================================
--- a/dist/master_data.csv
+++ b/dist/master_data.csv
@@ -1,6 +1,5 @@
 日本語,英語,キー
 こんにちは,hello,greeting.hello
 さようなら,good_bye,greeting.good_bye
 歓迎します,wellcome,greeting.welcome
-おやすみ,good night,greeting.good_night
-ばいばい,bye bye,greeting.bye_bye
\ No newline at end of file
+おやすみ,good night,greeting.good_night
\ No newline at end of file

```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
(node:56442) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:56442) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:56442) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:56442) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:56442) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
(node:56442) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:56442) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 6)
(node:56442) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:56442) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 7)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (7.022s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        7.818s
Ran all test suites.
```