### PR TITLE
Add 'created at' footer

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -26,7 +26,8 @@ const {
   colorize,
 } = require('./utils/string');
 
-const editor = require('./utils/editor');
+const editor = require('./utils/editor')
+  , moment = require('moment');
 
 const SitBaseRepo = require('./repos/base/SitBaseRepo');
 const SitConfig = require('./repos/SitConfig');
@@ -968,6 +969,7 @@ Dropped ${stashKey} (${stashCommitHash})`);
       }, [header]);
 
       data.push(['']);
+      data.push(['created at', moment().format()]);
       data.push(['reviewers', '']);
       data.push(['assignees', this.username()]);
       data.push(['message', '']);

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -1367,7 +1367,11 @@ cc8aa255b845ffbac3ef18b0fce15f7e8bac7e46 refs/heads/develop
           header,
           ['こんにちは', 'hello', 'common.greeting.hello'],
         ];
+        const mockCreatedAt = '2020-03-25T23:53:57+09:00';
+        mockMoment_format.mockReturnValueOnce(mockCreatedAt);
+
         model.createPullRequestData(toData, fromData, (result) => {
+          const mockCreatedAt = '2020-03-25T23:53:57+09:00';
           expect(result).toEqual(
             [
               ['日本語', '英語', 'キー', 'Index', 'Status'],
@@ -1375,6 +1379,7 @@ cc8aa255b845ffbac3ef18b0fce15f7e8bac7e46 refs/heads/develop
               ['さようなら', 'goodbye', 'common.greeting.good_bye', 1, '±'],
               ['おはよう', 'good morning', 'common.greeting.good_morning', 2, '±'],
               [''],
+              ['created at', mockCreatedAt],
               ['reviewers', ''],
               ['assignees', 'yukihirop'],
               ['message', ''],
@@ -1403,7 +1408,11 @@ cc8aa255b845ffbac3ef18b0fce15f7e8bac7e46 refs/heads/develop
           ['バイバイ', 'bye bye', 'common.greeting.bye_bye'],
           ['おやすみなさい', 'good night', 'common.greeting.good_night'],
         ];
+        const mockCreatedAt = '2020-03-25T23:53:57+09:00';
+        mockMoment_format.mockReturnValueOnce(mockCreatedAt);
+
         model.createPullRequestData(toData, fromData, (result) => {
+          const mockCreatedAt = '2020-03-25T23:53:57+09:00';
           expect(result).toEqual(
             [
               ['日本語', '英語', 'キー', 'Index', 'Status'],
@@ -1413,6 +1422,7 @@ cc8aa255b845ffbac3ef18b0fce15f7e8bac7e46 refs/heads/develop
               ['バイバイ', 'bye bye', 'common.greeting.bye_bye', 2, '+'],
               ['おやすみなさい', 'good night', 'common.greeting.good_night', 3, '+'],
               [''],
+              ['created at', mockCreatedAt],
               ['reviewers', ''],
               ['assignees', 'yukihirop'],
               ['message', ''],


### PR DESCRIPTION
## Summary

Fix #126 

## Work

![image](https://user-images.githubusercontent.com/11146767/77553011-9be9f500-6ef7-11ea-9ff5-9a53806e6c54.png)


## Test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:16849) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:16849) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:16849) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:16849) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:16849) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
(node:16848) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:16848) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:16848) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:16848) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:16848) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 FAIL  src/main/__tests__/SitRepo.spec.js
  ● SitRepo › #status › when modify dist file › should return correctly

    expect(received).toEqual(expected) // deep equality

    - Expected  - 4
    + Received  + 1

      On branch master
    -
    - 	modified: test/dist/test_data.csv
    -
    - no changes added to commit
    + nothing to commit

      583 |
      584 |         expect(console.log).toHaveBeenCalledTimes(1);
    > 585 |         expect(console.log.mock.calls[0][0]).toEqual(`\
          |                                              ^
      586 | On branch master\n\
      587 |
      588 | \t${colorize('modified: test/dist/test_data.csv', 'mark')}\n\

      at Object.<anonymous> (src/main/__tests__/SitRepo.spec.js:585:46)

  ● SitRepo › #status › when do not modify dist file › should return correctly

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 4

      Array [
        "On branch master
    - nothing to commit",
    +
    + 	modified: test/dist/test_data.csv
    +
    + no changes added to commit",
      ]

      606 |
      607 |         expect(console.log).toHaveBeenCalledTimes(1);
    > 608 |         expect(console.log.mock.calls[0]).toEqual(['On branch master\nnothing to commit']);
          |                                           ^
      609 |       });
      610 |     });
      611 |   });

      at Object.<anonymous> (src/main/__tests__/SitRepo.spec.js:608:43)

 PASS  src/main/sheets/__tests__/GSS.spec.js (5.735s)

Test Suites: 1 failed, 12 passed, 13 total
Tests:       2 failed, 15 skipped, 175 passed, 192 total
Snapshots:   0 total
Time:        6.197s, estimated 9s
Ran all test suites.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sit@1.0.0 test: `jest`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sit@1.0.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/yukihirop/.npm/_logs/2020-03-25T15_20_03_640Z-debug.log
```