### PR TITLE
Fix sit branch -a

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -201,13 +201,15 @@ class SitRepo extends SitBaseRepo {
         .then(files => {
           const result = files.reduce((acc, file) => {
             const refPath = pathRelative(this.localRepo, file);
-            const branch = this._branchResolve(refPath);
-            const refParser = new SitRefParser(this, branch, refPath);
+            if (refPath.indexOf('stash') === -1) {
+              const branch = this._branchResolve(refPath);
+              const refParser = new SitRefParser(this, branch, refPath);
 
-            if (branch === currentBranch) {
-              acc.push(`* ${refParser.displayedBranch()}`);
-            } else {
-              acc.push(`  ${refParser.displayedBranch()}`);
+              if (branch === currentBranch) {
+                acc.push(`* ${refParser.displayedBranch()}`);
+              } else {
+                acc.push(`  ${refParser.displayedBranch()}`);
+              }
             }
             return acc;
           }, []);


### PR DESCRIPTION
## Summary

Fix #129 

## Work


```diff
$ node index.js branch -a
- null
  dev-1
  dev-4
  dev-5
  dev-6
* dev-7
  develop
  master
  remotes/origin/dev-1
  remotes/origin/dev-3
  remotes/origin/dev-4
  remotes/origin/dev-5
  remotes/origin/dev-6
  remotes/origin/develop
  remotes/origin/master
```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:23719) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:23719) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:23719) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:23719) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:23719) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
(node:23718) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:23718) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:23718) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:23718) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:23718) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.982s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        6.505s, estimated 7s
Ran all test suites.
```