### PR TITLE
Fix sit push display log

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -169,6 +169,8 @@ To ${repo.remoteRepo(repoName)}`;
                 detailMsg = `\t+ ${detailMsg} (forced update)`;
               } else if (isNewBranch) {
                 detailMsg = `\t* [new branch]\t${detailMsg}`;
+              } else {
+                detailMsg = `\t${detailMsg}`;
               }
               console.log(`${baseMsg}\n${detailMsg}`);
             });


### PR DESCRIPTION
## Summary

Fix #130 

## Work

#### new branch

```
$ node index.js push origin hoge
Writed objects: 100% (1/1)
Total 1
remote:
remote: Create a pull request for hoge on GoogleSpreadSheet by visiting:
remote:     https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
remote:
To https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
	* [new branch]	0000000..7244522  hoge -> hoge
```

#### normal push

```
$ node index.js push origin hoge
Writed objects: 100% (1/1)
Total 1
remote:
remote: Create a pull request for hoge on GoogleSpreadSheet by visiting:
remote:     https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
remote:
To https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
	7244522..0cae686  hoge -> hoge
```

#### force push

```
$ node index.js push --force origin hoge
Writed objects: 100% (1/1)
Total 1
remote:
remote: Create a pull request for hoge on GoogleSpreadSheet by visiting:
remote:     https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
remote:
To https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
	+ 0cae686..c713351  hoge -> hoge (forced update)
```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:10440) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:10440) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:10440) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:10440) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:10440) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
(node:10438) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:10438) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:10438) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:10438) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:10438) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (7.822s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        12.123s
Ran all test suites.
```