### PR TITLE
Fix lint

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -321,6 +321,7 @@ Please make sure you have the correct access rights and the repository exists.`)
     }
   }
 
+  /* eslint-disable prefer-const */
   diff(opts = {}) {
     const { compareBlobHash } = opts;
     opts = Object.assign(opts, { type: 'blob' });
@@ -354,7 +355,7 @@ Please make sure you have the correct access rights and the repository exists.`)
       this.catFile(blobHash).then(obj => {
         const headStream = obj.serialize().toString();
         let { err, data } = fileSafeLoad(this.distFilePath);
-        data = data.trim()
+        data = data.trim();
 
         if (err) {
           die(err.message);
@@ -372,6 +373,7 @@ Please make sure you have the correct access rights and the repository exists.`)
       });
     }
   }
+  /* eslint-enable prefer-const */
 
   status(opts = {}) {
     opts = Object.assign(opts, { type: 'blob' });

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -582,9 +582,9 @@ Please make sure you have the correct access rights and the repository exists.`]
         model.status();
 
         expect(console.log).toHaveBeenCalledTimes(1);
-        expect(console.log.mock.calls[0][0]).toEqual(`\
+        expect(console.log.mock.calls[0][0]).toEqual('\
 On branch master\n\
-nothing to commit`);
+nothing to commit');
       });
     });
 


### PR DESCRIPTION
## Summary

Fix lint

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

(node:12109) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:12109) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:12109) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:12109) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:12109) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
(node:12108) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:12108) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:12108) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:12108) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:12108) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.472s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        7.11s, estimated 8s
Ran all test suites.
```

## lint

```
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/fukudayu/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```