### PR TITLE
define SIT_GOOGLE_SERVICE_ACCOUNT_EMAIL and SIT_GOOGLE_PRIVATE_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,15 @@ Commands:
   browse-remote [repository]                        browse remote repository
   config [options] <key> <value>                    configure sitconfig
   remote [options] <subcommand> <repository> [url]  set sitconfig
+  log [options]                                     Shows the commit logs
+  reflog                                            Shows the ref logs
+  show-ref                                          Show refs
+  rev-parse [options] [args]                        Many Sit porcelainish commands take mixture of flags
+  pull-request [options] <repository> <args>        Create pull request in Sheet
   init                                              create setting file (.sitsetting)
   clasp                                             clasp cli
   repo                                              repo cli
+  stash                                             stash cli
 ```
 
 ## ❤️ Support Sheets
@@ -120,4 +126,6 @@ dist:
 |----|-------|-------|
 |SIT_DIR||`.`|
 |SIT_SETTING_DIR||`.`|
+|SIT_GOOGLE_SERVICE_ACCOUNT_EMAIL|Google Service Account Email||
+|SIT_GOOGLE_PRIVATE_KEY|Google Private Key||
 

--- a/src/main/utils/file.js
+++ b/src/main/utils/file.js
@@ -84,7 +84,15 @@ const yamlDumpWriteSyncFile = (file, data) => {
 
 const jsonSafeLoad = (file) => {
   const fullPath = path.resolve(currentPath, file);
-  return require(fullPath);
+  let result;
+
+  try {
+    result = require(fullPath);
+  } catch (err) {
+    result = {};
+  }
+
+  return result;
 };
 
 const packageJSON = () => {


### PR DESCRIPTION
## Summary

Fix #137 

## Work

Use `direnv`

.envrc

```
export SIT_GOOGLE_SERVICE_ACCOUNT_EMAIL=
export SIT_GOOGLE_PRIVATE_KEY=
```

```
$ node index.js pull-request origin master...develop
Total 1
remote:
remote: Create a pull request for 'master' from 'develop' on GoogleSpreadSheet by visiting:
remote:     https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
remote:
To https://docs.google.com/spreadsheets/d/1jihJ2crH31nrAxFVJtuC6fwlioCi1EbnzMwCDqqhJ7k/edit#gid=1795377551
	Please look at sheet: '[pr] master...develop' in GoogleSpreadSheet
```

```
$ node index.js pull-request origin master...develop
error: Can not push for GoogleSpreadSheet
error: credentials file not found.
```

```
$ node index.js pull-request origin master...develop
error: Can not push for GoogleSpreadSheet
error: 'SIT_GOOGLE_SERVICE_ACCOUNT_EMAIL' is not set.
```

```
$ node index.js pull-request origin master...develop
error: Can not push for GoogleSpreadSheet
error: 'SIT_GOOGLE_PRIVATE_KEY' is not set.
```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

(node:32960) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:32960) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:32960) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:32960) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:32960) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
(node:32959) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:32959) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:32959) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:32959) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:32959) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.753s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        7.402s
Ran all test suites.
```

## Lint

```
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/fukudayu/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```