### PR TITLE
Fix display message when sit repo init

### DIFF
--- a/src/main/Clasp.js
+++ b/src/main/Clasp.js
@@ -29,17 +29,18 @@ class Clasp {
     const destClaspignorePath = absolutePath('./.claspignore');
 
     if (isExistFile(this.localRepo)) {
+      if (isExistFile(`${this.localRepo}/scripts/clasp`)) {
+        console.log(`updated script files: ${this.claspPath}`);
+      } else {
+        console.log(`created script files: ${this.claspPath}`);
+      }
+
       // copy .claspignore.
       fileCopySync(rootClaspignorePath, destClaspignorePath);
       // copy clasp/*.js into local repo.
       fileCopySync(`${rootFilesPath}`, `${destPath}`, { mkdirp: true });
       // append don't ignore GAS codes into .claspignore
       appendFile(`${destClaspignorePath}`, `!${fileBasename(this.localRepo)}/scripts/clasp/**/*.js`);
-      if (isExistFile(`${this.localRepo}/scripts/clasp`)) {
-        console.log(`update files: ${this.claspPath}`);
-      } else {
-        console.log(`create files: ${this.claspPath}`);
-      }
     } else {
       die(`Don't exists local repo: ${this.localRepo}.`);
     }

--- a/src/main/__tests__/Clasp.spec.js
+++ b/src/main/__tests__/Clasp.spec.js
@@ -47,7 +47,7 @@ describe('Clasp', () => {
         expect(appendFile.mock.calls[0]).toEqual([`${currentPath}/.claspignore`, '!.sit/scripts/clasp/**/*.js']);
 
         expect(console.log).toHaveBeenCalledTimes(1);
-        expect(console.log.mock.calls[0]).toEqual(['update files: test/localRepo/.sit/scripts/clasp']);
+        expect(console.log.mock.calls[0]).toEqual(['updated script files: test/localRepo/.sit/scripts/clasp']);
       });
 
       describe('when clasp scripts do not exist', () => {
@@ -60,7 +60,7 @@ describe('Clasp', () => {
           model.update();
 
           expect(console.log).toHaveBeenCalledTimes(1);
-          expect(console.log.mock.calls[0]).toEqual(['create files: test/localRepo/.sit/scripts/clasp']);
+          expect(console.log.mock.calls[0]).toEqual(['created script files: test/localRepo/.sit/scripts/clasp']);
         });
       });
     });

--- a/src/main/__tests__/index.spec.js
+++ b/src/main/__tests__/index.spec.js
@@ -270,7 +270,7 @@ Please make sure you have the correct access rights and the repository exists.`]
       sit().Repo.init();
 
       expect(console.log).toHaveBeenCalledTimes(2);
-      expect(console.log.mock.calls[0]).toEqual(['created local repo: test/localRepo/.sit']);
+      expect(console.log.mock.calls[0]).toEqual(['created local repository: test/localRepo/.sit']);
       expect(console.log.mock.calls[1]).toEqual(['created dist file: test/dist/test_data.csv']);
     });
   });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -242,7 +242,7 @@ remote: done.`);
     const data = sheet.header();
     const result = repo.init({ data });
     if (result) {
-      console.log(`created local repo: ${repo.localRepo}`);
+      console.log(`created local repository: ${repo.localRepo}`);
       console.log(`created dist file: ${repo.distFilePath}`);
     } else {
       console.log(`already exist local repo: ${repo.localRepo}`);


### PR DESCRIPTION
## Summary

Fix #144

## Work

```
$ sit repo init
created local repository: ./.sit
created dist file: dist/master_data.csv
created script files: .sit/scripts/clasp
```

```
$ sit repo init
already exist local repo: .sit
updated script files: .sit/scripts/clasp
```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

 PASS  src/main/__tests__/Clasp.spec.js
(node:44886) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:44886) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:44886) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:44886) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:44886) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:44887) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:44887) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:44887) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:44887) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:44887) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.794s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        6.341s, estimated 10s
Ran all test suites.
```

## Lint

```
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/fukudayu/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```
