### PR TITLE
Fix sit diff bugs

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -391,6 +391,23 @@ Please make sure you have the correct access rights and the repository exists.`)
             console.log(patch);
           }
         });
+      } else {
+        const headStream = '';
+        let { err, data } = fileSafeLoad(this.distFilePath);
+        data = data.trim();
+        if (err) {
+          die(err.message);
+        }
+        if (headStream !== data) {
+          let patch = jsdiff.createPatch(index, headStream, data, `a/${this.distFilePath}`, `b/${this.distFilePath}`);
+          patch = patch
+            .replace(/^[---].*\t/gm, '--- ')
+            .replace(/^[+++].*\t/gm, '+++ ')
+            .replace(/^\-.*/gm, colorize('$&', 'removed'))
+            .replace(/^\+.*/gm, colorize('$&', 'added'))
+            .replace(/^@@.+@@/gm, colorize('$&', 'section'));
+          console.log(patch);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

## Work

first time diff

```
$ sit diff
Index: 0000000..35daa93
===================================================================
--- a/dist/master_data.csv
+++ b/dist/master_data.csv
@@ -1,0 +1,1 @@
\ No newline at end of file
+日本語,英語,キー
\ No newline at end of file

```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

(node:53667) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:53667) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:53667) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:53667) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:53667) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
(node:53666) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:53666) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:53666) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:53666) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:53666) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.821s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        7.521s, estimated 10s
Ran all test suites.
```

## Lint

```
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/fukudayu/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```