### PR TITLE
Fix sit merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,11 @@ program
     '--abort',
     'abort merge'
   )
+  .option(
+    '-t, --type <type>',
+    'sheet type',
+    'GoogleSpreadSheet'
+  )
   .action((repository, branch, options) => {
     sit().Repo.merge(repository, branch, options);
   });

--- a/src/main/__tests__/SitRepo.spec.js
+++ b/src/main/__tests__/SitRepo.spec.js
@@ -895,7 +895,7 @@ fatal: Existing because of an unresolved conflict.`]);
         expect(mockModel__deleteSyncFile.mock.calls[2]).toEqual(['MERGE_HEAD']);
 
         expect(mockModel_catFile).toHaveBeenCalledTimes(1);
-        expect(mockModel_catFile.mock.calls[0]).toEqual(['4e2b7c47eb492ab07c5d176dccff3009c1ebc79b']);
+        expect(mockModel_catFile.mock.calls[0]).toEqual(['2938ad2ab5722adf9b48ff5bac74989eaa2d144c']);
       });
     });
 
@@ -931,19 +931,14 @@ Please, commit your changes before you merge.`]);
 
     describe('when merge origin master (conflict)', () => {
       it('should return correctly', () => {
-        const obj = new SitBlob(model, '1,2,3', 3);
         jest.spyOn(model, '_writeSyncFile').mockReturnValue(model);
         jest.spyOn(model, '_writeLog').mockReturnValue(model);
         jest.spyOn(model, 'hashObjectFromData').mockReturnValue(true);
-        const mockModel__isExistFile = jest.spyOn(model, '_isExistFile').mockReturnValue(false);
-        const mockModel_catFile = jest.spyOn(model, 'catFile').mockReturnValueOnce(Promise.resolve(obj));
+        const mockModel__isExistFile = jest.spyOn(model, '_isExistFile').mockReturnValueOnce(false);
         model.merge('origin', 'master');
 
         expect(mockModel__isExistFile).toHaveBeenCalledTimes(1);
         expect(mockModel__isExistFile.mock.calls[0]).toEqual(['MERGE_HEAD']);
-
-        expect(mockModel_catFile).toHaveBeenCalledTimes(1);
-        expect(mockModel_catFile.mock.calls[0]).toEqual(['4e2b7c47eb492ab07c5d176dccff3009c1ebc79b']);
       });
     });
   });


### PR DESCRIPTION
## Summary

Fix  #146
Fix #142

## Work

```bash
$ sit merge origin master
Updating 19fbaa4..538ff98
Fast-forward
  dist/master_data.csv
  1 file changed

```

```bash
$ sit cat-file -p HEAD
blob b0122f0795b0be80d51a7ff6946f00bf0300e723
parent 19fbaa466f37f6ce9589db93ec09627c2ac540e2
author yukihirop <te108186@gmail.com> 1585557722482 +0900
committer GoogleSpreadSheet <noreply@googlespreadsheet.com> 1585557722482 +0900
Merge from GoogleSpreadSheet/master
```

```bash
$ sit cat-file -p b0122f0795b0be80d51a7ff6946f00bf0300e723
日本語,英語,キー
こんにちは,hello,greeting.hello
```

```bash
$ sit merge origin master
Two-way-merging dist/master_data.csv
CONFLICT (content): Merge conflict in dist/master_data.csv
two-way-merge failed; fix conflicts and then commit the result.
```

```bash
$ sit merge --stat
fatal: You have not concluded your merge (MERGE_HEAD exists)
Please, commit your changes before you merge.
```

```
$ sit merge --continue
hint: Waiting for your editor to close the file...
[master 75ff340] Merge remote-tracking branch 'origin/master' into master
^C
```

```
$ sit cat-file -p HEAD
blob 9bb9157f79f0a7b419d2df3862401092afcc87c5
parent 5cbf8be9e14bedb0b1941d395b783b18d18144ce
author yukihirop <te108186@gmail.com> 1585561598978 +0900
committer GoogleSpreadSheet <noreply@googlespreadsheet.com> 1585561598978 +0900

Merge from GoogleSpreadSheet/master
```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

(node:83814) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:83814) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:83814) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:83814) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:83814) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
(node:83813) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:83813) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:83813) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:83813) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:83813) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.197s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        6.935s, estimated 7s
Ran all test suites.
```

## Lint

```
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/fukudayu/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```