### PR TITLE
Fix sit stash save/list

### DIFF
--- a/src/main/SitRepo.js
+++ b/src/main/SitRepo.js
@@ -921,7 +921,11 @@ Dropped ${stashKey} (${stashCommitHash})`);
       const parser = new SitLogParser(this, currentBranch, 'logs/refs/stash');
       try {
         const stashList = parser.parseForLog('stash');
-        console.log(stashList);
+        if (stashList === '') {
+          console.log('stash list is nothing');
+        } else {
+          console.log(stashList);
+        }
       } catch (err) {
         console.log('stash list is nothing');
       }
@@ -940,7 +944,7 @@ Dropped ${stashKey} (${stashCommitHash})`);
       let { stashKey } = opts;
       if (!stashKey) stashKey = 'stash@{0}';
 
-      const deleteStashKey = this._refStash(stashKey, false);
+      const deleteStashCommitHash = this._refStash(stashKey, false);
 
       if (stashKey === 'stash@{0}') {
         this._writeSyncFile('refs/stash', this._refStash(stashKey, true));
@@ -948,9 +952,9 @@ Dropped ${stashKey} (${stashCommitHash})`);
       this._deleteLineLog('logs/refs/stash', stashKey);
 
       if (stashKey === 'stash@{0}') {
-        console.log(`Dropped refs/stash@{0} (${deleteStashKey})`);
+        console.log(`Dropped refs/stash@{0} (${deleteStashCommitHash})`);
       } else {
-        console.log(`Dropped ${stashKey} (${deleteStashKey})`);
+        console.log(`Dropped ${stashKey} (${deleteStashCommitHash})`);
       }
     }
   }

--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -218,7 +218,8 @@ class SitBaseRepo extends SitBase {
     let { err, data } = fileSafeLoad(this.__repoFile(false, 'COMMIT_EDITMSG'));
     if (err) die(err.message);
     data = data.trim();
-    return data;
+    // Use only the first line message
+    return data.split('\n')[0];
   }
   /* eslint-enable prefer-const */
 
@@ -628,10 +629,15 @@ class SitBaseRepo extends SitBase {
     const index = parser.parseForIndex('stash');
     let stashCommitHash;
 
-    if (next) {
+    if (next && Object.keys(index).length > 1) {
       stashCommitHash = index[this._nextKey(stashKey)].aftersha;
     } else {
-      stashCommitHash = index[stashKey].aftersha;
+      const data = index[stashKey]
+      if (data) {
+        stashCommitHash = index[stashKey].aftersha;
+      } else {
+        die(`${stashKey} is not a valid reference`);
+      }
     }
 
     return stashCommitHash;


### PR DESCRIPTION
## Summary

Fix #156 

## Work

```bash
Saved working directory and index state WIP on master: 08d2106 Merge remote-tracking branch 'origin/master'

# Conflict
#	dist/master_data.csv
#
# It looks like you may be committing a merge.
# If this is not correct, please remove the file
# 	.sit/MERGE_HEAD
# and try again.


# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch develop
# All conflicts fixed but you are still merging.
#
# Changes for commit:
#	modified:	dist/master_data.csv
#
```

```bash
$ sit stash save
Saved working directory and index state WIP on master: 08d2106 Merge remote-tracking branch 'origin/master'
```

## Test

```
$ npm run test

> sit@1.0.0 test /Users/fukudayu/JavaScripts/sit
> jest

(node:31331) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:31331) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:31331) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:31331) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:31331) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
(node:31330) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:31330) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:31330) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:31330) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:31330) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.684s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        7.267s, estimated 12s
Ran all test suites.
```

## Lint

```bash
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/fukudayu/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```