### PR TITLE
Support sit cat-file -p MERGE_HEAD

### DIFF
--- a/src/main/repos/base/SitBaseRepo.js
+++ b/src/main/repos/base/SitBaseRepo.js
@@ -546,6 +546,8 @@ class SitBaseRepo extends SitBase {
         resolve([this._refResolve('REMOTE_HEAD')]);
       } else if (name === 'FETCH_HEAD') {
         resolve([this._refResolve('FETCH_HEAD')]);
+      } else if (name === 'MERGE_HEAD') {
+        resolve([this._refResolve('MERGE_HEAD')]);
       }
 
       if (name.match(hashRE)) {


### PR DESCRIPTION
## Summary

Fix #153 

## Work

```bash
$ sit cat-file -p MERGE_HEAD
日本語,英語,キー
こんにちは,hello,common.greeting.hello
さようなら,goodbye,common.greeting.good_bye
おやすみなさい,good_night,common.greeting.good_night
バイバイ,bye bye,common.byebye
ブイブイ,bui bui,common.buibui
あーあー,aa,common.aa
```

## Test

```bash

> sit@1.0.0 test /Users/yukihirop/JavaScriptProjects/sit
> jest

 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
(node:9757) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:9757) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:9757) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:9757) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:9757) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
(node:9755) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:9755) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:9755) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:9755) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:9755) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (6.229s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        8.286s
Ran all test suites.
```

## Lint

```
$ npm run nibble:main

> sit@1.0.0 nibble:main /Users/yukihirop/JavaScriptProjects/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```