### PR TITLE
Fix sit -V(--version) before sit init

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,9 @@ if (process.argv.length <= 2) {
     process.argv.indexOf('-h') == -1,
     process.argv.indexOf('--help') == -1,
     process.argv.indexOf('clone') == -1,
-    process.argv.indexOf('init') == -1
+    process.argv.indexOf('init') == -1,
+    process.argv.indexOf('--version') == -1,
+    process.argv.indexOf('-V') == -1
   ];
   const isCheck = !checkConditions.some(c => c === false);
 


### PR DESCRIPTION
## Summary

Fix #167 

## Work

```
$ /Users/yukihirop/JavaScripts/sit-tutorial-2/node_modules/@yukihirop/sit/index.js --version
1.0.0

$ ll
total 4.0K
drwxr-xr-x 4 yukihirop 128  4  3 10:30 node_modules
-rw-r--r-- 1 yukihirop  27  4  3 10:32 package-lock.json
```

## Test

```
$ npm run test

> @yukihirop/sit@1.0.0 test /Users/yukihirop/JavaScripts/sit
> jest

(node:21428) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:21428) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:21428) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:21428) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'then' of undefined
(node:21428) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
 PASS  src/main/__tests__/index.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseRepo.spec.js
(node:21426) UnhandledPromiseRejectionWarning: Error: process.exit() was called.
(node:21426) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:21426) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:21426) UnhandledPromiseRejectionWarning: Error: No such reference null.
(node:21426) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
 PASS  src/main/__tests__/SitRepo.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseLogger.spec.js
 PASS  src/main/__tests__/Clasp.spec.js
 PASS  src/main/repos/logs/__tests__/SitLogParser.spec.js
 PASS  src/main/repos/refs/__tests__/SitRefParser.spec.js
 PASS  src/main/repos/objects/__tests__/SitCommit.spec.js
 PASS  src/main/repos/base/__tests__/SitBaseConfig.spec.js
 PASS  src/main/repos/validators/__tests__/SitRepoValidator.spec.js
 PASS  src/main/repos/objects/__tests__/SitBlob.spec.js
 PASS  src/main/repos/base/__tests__/SitBase.spec.js
 PASS  src/main/sheets/__tests__/GSS.spec.js (5.903s)

Test Suites: 13 passed, 13 total
Tests:       15 skipped, 177 passed, 192 total
Snapshots:   0 total
Time:        11.372s
Ran all test suites.
```

## Lint

```
$ npm run nibble:main

> @yukihirop/sit@1.0.0 nibble:main /Users/yukihirop/JavaScripts/sit
> eslint-nibble --ext .js src/main

Great job, all lint rules passed.
```
